### PR TITLE
chore: prepare next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.6.0 - tbd
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ## Version 0.5.0 - 2023-05-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/graphql",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CDS protocol adapter for GraphQL",
   "keywords": [
     "CAP",


### PR DESCRIPTION
Requires https://github.com/cap-js/graphql/pull/81 to fix failing test