### PR TITLE
test: regenerate `bookshop-graphql` schema

### DIFF
--- a/test/schemas/bookshop-graphql.gql
+++ b/test/schemas/bookshop-graphql.gql
@@ -118,10 +118,10 @@ type AdminService_Authors_input {
     input: [AdminService_Authors_C]!
   ): [AdminService_Authors]
   delete(
-    filter: [AdminService_Authors_filter]
+    filter: [AdminService_Authors_filter]!
   ): Int
   update(
-    filter: [AdminService_Authors_filter]
+    filter: [AdminService_Authors_filter]!
     input: AdminService_Authors_U!
   ): [AdminService_Authors]
 }
@@ -237,10 +237,10 @@ type AdminService_Books_input {
     input: [AdminService_Books_C]!
   ): [AdminService_Books]
   delete(
-    filter: [AdminService_Books_filter]
+    filter: [AdminService_Books_filter]!
   ): Int
   update(
-    filter: [AdminService_Books_filter]
+    filter: [AdminService_Books_filter]!
     input: AdminService_Books_U!
   ): [AdminService_Books]
 }
@@ -297,10 +297,10 @@ type AdminService_Books_texts_input {
     input: [AdminService_Books_texts_C]!
   ): [AdminService_Books_texts]
   delete(
-    filter: [AdminService_Books_texts_filter]
+    filter: [AdminService_Books_texts_filter]!
   ): Int
   update(
-    filter: [AdminService_Books_texts_filter]
+    filter: [AdminService_Books_texts_filter]!
     input: AdminService_Books_texts_U!
   ): [AdminService_Books_texts]
 }
@@ -362,10 +362,10 @@ type AdminService_Chapters_input {
     input: [AdminService_Chapters_C]!
   ): [AdminService_Chapters]
   delete(
-    filter: [AdminService_Chapters_filter]
+    filter: [AdminService_Chapters_filter]!
   ): Int
   update(
-    filter: [AdminService_Chapters_filter]
+    filter: [AdminService_Chapters_filter]!
     input: AdminService_Chapters_U!
   ): [AdminService_Chapters]
 }
@@ -429,10 +429,10 @@ type AdminService_Currencies_input {
     input: [AdminService_Currencies_C]!
   ): [AdminService_Currencies]
   delete(
-    filter: [AdminService_Currencies_filter]
+    filter: [AdminService_Currencies_filter]!
   ): Int
   update(
-    filter: [AdminService_Currencies_filter]
+    filter: [AdminService_Currencies_filter]!
     input: AdminService_Currencies_U!
   ): [AdminService_Currencies]
 }
@@ -481,10 +481,10 @@ type AdminService_Currencies_texts_input {
     input: [AdminService_Currencies_texts_C]!
   ): [AdminService_Currencies_texts]
   delete(
-    filter: [AdminService_Currencies_texts_filter]
+    filter: [AdminService_Currencies_texts_filter]!
   ): Int
   update(
-    filter: [AdminService_Currencies_texts_filter]
+    filter: [AdminService_Currencies_texts_filter]!
     input: AdminService_Currencies_texts_U!
   ): [AdminService_Currencies_texts]
 }
@@ -552,10 +552,10 @@ type AdminService_Genres_input {
     input: [AdminService_Genres_C]!
   ): [AdminService_Genres]
   delete(
-    filter: [AdminService_Genres_filter]
+    filter: [AdminService_Genres_filter]!
   ): Int
   update(
-    filter: [AdminService_Genres_filter]
+    filter: [AdminService_Genres_filter]!
     input: AdminService_Genres_U!
   ): [AdminService_Genres]
 }
@@ -603,10 +603,10 @@ type AdminService_Genres_texts_input {
     input: [AdminService_Genres_texts_C]!
   ): [AdminService_Genres_texts]
   delete(
-    filter: [AdminService_Genres_texts_filter]
+    filter: [AdminService_Genres_texts_filter]!
   ): Int
   update(
-    filter: [AdminService_Genres_texts_filter]
+    filter: [AdminService_Genres_texts_filter]!
     input: AdminService_Genres_texts_U!
   ): [AdminService_Genres_texts]
 }
@@ -777,10 +777,10 @@ type CatalogService_Books_input {
     input: [CatalogService_Books_C]!
   ): [CatalogService_Books]
   delete(
-    filter: [CatalogService_Books_filter]
+    filter: [CatalogService_Books_filter]!
   ): Int
   update(
-    filter: [CatalogService_Books_filter]
+    filter: [CatalogService_Books_filter]!
     input: CatalogService_Books_U!
   ): [CatalogService_Books]
 }
@@ -835,10 +835,10 @@ type CatalogService_Books_texts_input {
     input: [CatalogService_Books_texts_C]!
   ): [CatalogService_Books_texts]
   delete(
-    filter: [CatalogService_Books_texts_filter]
+    filter: [CatalogService_Books_texts_filter]!
   ): Int
   update(
-    filter: [CatalogService_Books_texts_filter]
+    filter: [CatalogService_Books_texts_filter]!
     input: CatalogService_Books_texts_U!
   ): [CatalogService_Books_texts]
 }
@@ -900,10 +900,10 @@ type CatalogService_Chapters_input {
     input: [CatalogService_Chapters_C]!
   ): [CatalogService_Chapters]
   delete(
-    filter: [CatalogService_Chapters_filter]
+    filter: [CatalogService_Chapters_filter]!
   ): Int
   update(
-    filter: [CatalogService_Chapters_filter]
+    filter: [CatalogService_Chapters_filter]!
     input: CatalogService_Chapters_U!
   ): [CatalogService_Chapters]
 }
@@ -967,10 +967,10 @@ type CatalogService_Currencies_input {
     input: [CatalogService_Currencies_C]!
   ): [CatalogService_Currencies]
   delete(
-    filter: [CatalogService_Currencies_filter]
+    filter: [CatalogService_Currencies_filter]!
   ): Int
   update(
-    filter: [CatalogService_Currencies_filter]
+    filter: [CatalogService_Currencies_filter]!
     input: CatalogService_Currencies_U!
   ): [CatalogService_Currencies]
 }
@@ -1019,10 +1019,10 @@ type CatalogService_Currencies_texts_input {
     input: [CatalogService_Currencies_texts_C]!
   ): [CatalogService_Currencies_texts]
   delete(
-    filter: [CatalogService_Currencies_texts_filter]
+    filter: [CatalogService_Currencies_texts_filter]!
   ): Int
   update(
-    filter: [CatalogService_Currencies_texts_filter]
+    filter: [CatalogService_Currencies_texts_filter]!
     input: CatalogService_Currencies_texts_U!
   ): [CatalogService_Currencies_texts]
 }
@@ -1090,10 +1090,10 @@ type CatalogService_Genres_input {
     input: [CatalogService_Genres_C]!
   ): [CatalogService_Genres]
   delete(
-    filter: [CatalogService_Genres_filter]
+    filter: [CatalogService_Genres_filter]!
   ): Int
   update(
-    filter: [CatalogService_Genres_filter]
+    filter: [CatalogService_Genres_filter]!
     input: CatalogService_Genres_U!
   ): [CatalogService_Genres]
 }
@@ -1141,10 +1141,10 @@ type CatalogService_Genres_texts_input {
     input: [CatalogService_Genres_texts_C]!
   ): [CatalogService_Genres_texts]
   delete(
-    filter: [CatalogService_Genres_texts_filter]
+    filter: [CatalogService_Genres_texts_filter]!
   ): Int
   update(
-    filter: [CatalogService_Genres_texts_filter]
+    filter: [CatalogService_Genres_texts_filter]!
     input: CatalogService_Genres_texts_U!
   ): [CatalogService_Genres_texts]
 }
@@ -1239,10 +1239,10 @@ type CatalogService_ListOfBooks_input {
     input: [CatalogService_ListOfBooks_C]!
   ): [CatalogService_ListOfBooks]
   delete(
-    filter: [CatalogService_ListOfBooks_filter]
+    filter: [CatalogService_ListOfBooks_filter]!
   ): Int
   update(
-    filter: [CatalogService_ListOfBooks_filter]
+    filter: [CatalogService_ListOfBooks_filter]!
     input: CatalogService_ListOfBooks_U!
   ): [CatalogService_ListOfBooks]
 }


### PR DESCRIPTION
`bookshop-graphql.gql` was previously ignored due to https://github.com/cap-js/graphql/pull/70, but since then https://github.com/cap-js/graphql/pull/73 has changed schema generation. This PR incorporates the new schema generation changes from PR https://github.com/cap-js/graphql/pull/73

(fixes currently failing `bookshop-graphql.gql` test in other PRs)