### PR TITLE
chore: remove `cds` from `devDependencies` and update node matrix test versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]  # see https://nodejs.org/en/about/releases/
+        node-version: [16.x, 18.x, 20.x]  # see https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]  # see https://nodejs.org/en/about/releases/
+        node-version: [16.x, 18.x]  # see https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@sap/cds": ">=6.3"
   },
   "devDependencies": {
-    "@sap/cds": ">=6.3",
     "axios": ">=0.24",
     "eslint": "^8",
     "express": "^4.17.1",


### PR DESCRIPTION
With node 14 it was necessary to keep `cds` in `devDependencies` as well as a `peerDependencies` since node 14 comes with npm 6 and npm<7 does not install `peerDependencies`. Now that node 14 has reached End-of-Life, it has been removed from the matrix tests and the entry from `devDependencies` can be removed. As node 20 is the current node version, it has been added to the matrix tests.

related: https://github.com/cap-js/graphql/commit/6fac2c0372faa888d0a1c2cbcd0eed51242fde7b https://github.com/cap-js/graphql/pull/88