### PR TITLE
fix: GraphiQL Explorer Plugin CDN URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Changed GraphiQL Explorer Plugin CDN URL due to upstream renaming
+
 ### Removed
 
 ## Version 0.6.0 - 2023-06-23

--- a/app/graphiql.html
+++ b/app/graphiql.html
@@ -25,7 +25,7 @@
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 
     <script crossorigin src="https://unpkg.com/graphiql/graphiql.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@graphiql/plugin-explorer/dist/graphiql-plugin-explorer.umd.js"></script>
+    <script crossorigin src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"></script>
 
     <script>
       const fetcher = GraphiQL.createFetcher({ url: '' })


### PR DESCRIPTION
The dist filename of the GraphiQL Explorer Plugin changed upstream causing the CDN URL to need to be adjusted.

See: https://github.com/graphql/graphiql/releases/tag/%40graphiql%2Fplugin-explorer%400.2.0