### PR TITLE
fix: GraphiQL Explorer Plugin init function usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- GraphiQL Explorer Plugin initialization due to upstream function signature change
+- GraphiQL Explorer Plugin initialization due to upstream implementation pattern change
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GraphiQL Explorer Plugin initialization due to upstream function signature change
+
 ### Removed
 
 ## Version 0.6.1 - 2023-07-05

--- a/app/graphiql.html
+++ b/app/graphiql.html
@@ -31,14 +31,11 @@
       const fetcher = GraphiQL.createFetcher({ url: '' })
 
       function GraphiQLWithExplorer() {
-        const [query, setQuery] = React.useState()
-        const explorerPlugin = GraphiQLPluginExplorer.useExplorerPlugin({ query, onEdit: setQuery })
+        const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin()
         return React.createElement(GraphiQL, {
           fetcher,
           defaultEditorToolsVisibility: true,
-          plugins: [explorerPlugin],
-          query,
-          onEditQuery: setQuery
+          plugins: [explorerPlugin]
         })
       }
 


### PR DESCRIPTION
The implementation pattern of the GraphiQL Explorer Plugin changed upstream causing the initialization to need to be adjusted.

See: https://github.com/graphql/graphiql/releases/tag/%40graphiql%2Fplugin-explorer%400.3.0