### PR TITLE
test: `null` AST convenience value in lists and filter operator conjunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Name clashes when CDS elements are named `nodes` or `totalCount`
+- Parsing of `null` values in lists
 
 ### Removed
 

--- a/test/tests/enrich.test.js
+++ b/test/tests/enrich.test.js
@@ -302,5 +302,23 @@ describe('graphql - enrich AST ', () => {
       const value = enrichedAST[0].selectionSet.selections[0].arguments[0].value.fields[0].value.fields[0].value.value
       expect(value).toEqual(null)
     })
+
+    test('null value passed as nested input value within a list has a value of null', async () => {
+      const query = gql`
+        {
+          AdminService {
+            Books(filter: { ID: { ne: [1, null, 3] } }) {
+              totalCount
+            }
+          }
+        }
+      `
+      const document = parse(query)
+      const fakeInfo = fakeInfoObject(document, bookshopSchema, 'Query')
+      const enrichedAST = enrich(fakeInfo)
+      const value =
+        enrichedAST[0].selectionSet.selections[0].arguments[0].value.fields[0].value.fields[0].value.values[1].value
+      expect(value).toEqual(null)
+    })
   })
 })

--- a/test/tests/queries/filter.test.js
+++ b/test/tests/queries/filter.test.js
@@ -235,6 +235,33 @@ describe('graphql - filter', () => {
         expect(response.data).toEqual({ data })
       })
 
+      test('query with filter operator conjunction', async () => {
+        const query = gql`
+          {
+            AdminService {
+              Books(filter: { ID: { ne: [201, 207, 251] } }) {
+                nodes {
+                  ID
+                  title
+                }
+              }
+            }
+          }
+        `
+        const data = {
+          AdminService: {
+            Books: {
+              nodes: [
+                { ID: 252, title: 'Eleonora' },
+                { ID: 271, title: 'Catweazle' }
+              ]
+            }
+          }
+        }
+        const response = await POST('/graphql', { query })
+        expect(response.data).toEqual({ data })
+      })
+
       test('query with simple filter wrapped as lists', async () => {
         const query = gql`
           {


### PR DESCRIPTION
Re: changelog entry:
```
- Parsing of `null` values in lists
```
&rarr; fixed by https://github.com/cap-js/graphql/pull/139