### PR TITLE
feat: only compile services with GraphQL protocol annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@graphiql/plugin-explorer` version to `^1`
+- When compiling to GraphQL using the CDS API or CLI, only generate GraphQL schemas for services that are annotated with GraphQL protocol annotations
 
 ### Fixed
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,8 +5,13 @@ const { lexicographicSortSchema, printSchema } = require('graphql')
 function cds_compile_to_gql(csn, options = {}) {
   const m = cds.linked(csn)
   const services = Object.fromEntries(m.services.map(s => [s.name, new cds.ApplicationService(s.name, m)]))
+  const gqlServices = Object.fromEntries(
+    Object.entries(services).filter(([_, service]) =>
+      service.definition.endpoints.some(e => e.kind.match(/graphql/))
+    )
+  )
 
-  let schema = generateSchema4(services)
+  let schema = generateSchema4(gqlServices)
 
   if (options.sort) schema = lexicographicSortSchema(schema)
   if (/^obj|object$/i.test(options.as)) return schema

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -8,7 +8,7 @@ function cds_compile_to_gql(csn, options = {}) {
     m.services
       .map(s => [s.name, new cds.ApplicationService(s.name, m)])
       // Only compile services with graphql endpoints
-      .filter(([_, service]) => service.definition.endpoints.some(e => e.kind.match(/graphql/)))
+      .filter(([_, service]) => service.definition.endpoints.some(e => e.kind.match(/graphql/i)))
   )
 
   let schema = generateSchema4(services)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -4,14 +4,14 @@ const { lexicographicSortSchema, printSchema } = require('graphql')
 
 function cds_compile_to_gql(csn, options = {}) {
   const m = cds.linked(csn)
-  const services = Object.fromEntries(m.services.map(s => [s.name, new cds.ApplicationService(s.name, m)]))
-  const gqlServices = Object.fromEntries(
-    Object.entries(services).filter(([_, service]) =>
-      service.definition.endpoints.some(e => e.kind.match(/graphql/))
-    )
+  const services = Object.fromEntries(
+    m.services
+      .map(s => [s.name, new cds.ApplicationService(s.name, m)])
+      // Only compile services with graphql endpoints
+      .filter(([_, service]) => service.definition.endpoints.some(e => e.kind.match(/graphql/)))
   )
 
-  let schema = generateSchema4(gqlServices)
+  let schema = generateSchema4(services)
 
   if (options.sort) schema = lexicographicSortSchema(schema)
   if (/^obj|object$/i.test(options.as)) return schema

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -2,13 +2,29 @@ const cds = require('@sap/cds')
 const { generateSchema4 } = require('./schema')
 const { lexicographicSortSchema, printSchema } = require('graphql')
 
+const _isServiceAnnotatedWithGraphQL = service => {
+  const { definition } = service
+
+  if (definition['@graphql']) return true
+
+  const protocol = definition['@protocol']
+  if (protocol) {
+    // @protocol: 'graphql' or @protocol: ['graphql', 'odata']
+    const protocols = Array.isArray(protocol) ? protocol : [protocol]
+    // Normalize objects such as { kind: 'graphql' } to strings
+    return protocols.map(p => (typeof p === 'object' ? p.kind : p)).some(p => p.match(/graphql/i))
+  }
+
+  return false
+}
+
 function cds_compile_to_gql(csn, options = {}) {
   const m = cds.linked(csn)
   const services = Object.fromEntries(
     m.services
       .map(s => [s.name, new cds.ApplicationService(s.name, m)])
-      // Only compile services with graphql endpoints
-      .filter(([_, service]) => service.definition.endpoints.some(e => e.kind.match(/graphql/i)))
+      // Only compile services with GraphQL endpoints
+      .filter(([_, service]) => _isServiceAnnotatedWithGraphQL(service))
   )
 
   let schema = generateSchema4(services)

--- a/test/resources/annotations/srv/protocols.cds
+++ b/test/resources/annotations/srv/protocols.cds
@@ -11,7 +11,7 @@ service AnnotatedWithAtProtocolNone {
   }
 }
 
-@protocol: 'odata-v4'
+@protocol: 'odata'
 service AnnotatedWithNonGraphQL {
   entity A {
     key id : UUID;

--- a/test/resources/annotations/srv/protocols.cds
+++ b/test/resources/annotations/srv/protocols.cds
@@ -4,6 +4,13 @@ service NotAnnotated {
   }
 }
 
+@protocol: 'none'
+service AnnotatedWithAtProtocolNone {
+  entity A {
+    key id : UUID;
+  }
+}
+
 @protocol: 'odata-v4'
 service AnnotatedWithNonGraphQL {
   entity A {

--- a/test/resources/annotations/srv/protocols.cds
+++ b/test/resources/annotations/srv/protocols.cds
@@ -4,6 +4,13 @@ service NotAnnotated {
   }
 }
 
+@protocol: 'odata-v4'
+service AnnotatedWithNonGraphQL {
+  entity A {
+    key id : UUID;
+  }
+}
+
 @graphql
 service AnnotatedWithAtGraphQL {
   entity A {

--- a/test/resources/edge-cases/srv/field-named-localized.cds
+++ b/test/resources/edge-cases/srv/field-named-localized.cds
@@ -1,5 +1,6 @@
 using {managed} from '@sap/cds/common';
 
+@graphql
 service FieldNamedLocalizedService {
   entity localized {
     key ID        : Integer;

--- a/test/resources/model-structure/srv/composition-of-aspect.cds
+++ b/test/resources/model-structure/srv/composition-of-aspect.cds
@@ -1,3 +1,4 @@
+@protocol: ['graphql']
 service CompositionOfAspectService {
   entity Books {
     key id       : UUID;

--- a/test/resources/models.json
+++ b/test/resources/models.json
@@ -8,6 +8,10 @@
     "requires_cds": ">=6.8.0"
   },
   {
+    "name": "annotations",
+    "files": ["./annotations/srv/protocols.cds"]
+  },
+  {
     "name": "types",
     "files": ["./types/srv/types.cds"]
   },

--- a/test/schemas/annotations.gql
+++ b/test/schemas/annotations.gql
@@ -138,6 +138,7 @@ input ID_filter {
   eq: ID
   ge: ID
   gt: ID
+  in: [ID]
   le: ID
   lt: ID
   ne: [ID]

--- a/test/schemas/annotations.gql
+++ b/test/schemas/annotations.gql
@@ -1,0 +1,163 @@
+type AnnotatedWithAtGraphQL {
+  A(filter: [AnnotatedWithAtGraphQL_A_filter], orderBy: [AnnotatedWithAtGraphQL_A_orderBy], skip: Int, top: Int): AnnotatedWithAtGraphQL_A_connection
+}
+
+type AnnotatedWithAtGraphQL_A {
+  id: ID
+}
+
+input AnnotatedWithAtGraphQL_A_C {
+  id: ID
+}
+
+type AnnotatedWithAtGraphQL_A_connection {
+  nodes: [AnnotatedWithAtGraphQL_A]
+  totalCount: Int
+}
+
+input AnnotatedWithAtGraphQL_A_filter {
+  id: [ID_filter]
+}
+
+type AnnotatedWithAtGraphQL_A_input {
+  create(input: [AnnotatedWithAtGraphQL_A_C]!): [AnnotatedWithAtGraphQL_A]
+  delete(filter: [AnnotatedWithAtGraphQL_A_filter]!): Int
+}
+
+input AnnotatedWithAtGraphQL_A_orderBy {
+  id: SortDirection
+}
+
+type AnnotatedWithAtGraphQL_input {
+  A: AnnotatedWithAtGraphQL_A_input
+}
+
+type AnnotatedWithAtProtocolObjectList {
+  A(filter: [AnnotatedWithAtProtocolObjectList_A_filter], orderBy: [AnnotatedWithAtProtocolObjectList_A_orderBy], skip: Int, top: Int): AnnotatedWithAtProtocolObjectList_A_connection
+}
+
+type AnnotatedWithAtProtocolObjectList_A {
+  id: ID
+}
+
+input AnnotatedWithAtProtocolObjectList_A_C {
+  id: ID
+}
+
+type AnnotatedWithAtProtocolObjectList_A_connection {
+  nodes: [AnnotatedWithAtProtocolObjectList_A]
+  totalCount: Int
+}
+
+input AnnotatedWithAtProtocolObjectList_A_filter {
+  id: [ID_filter]
+}
+
+type AnnotatedWithAtProtocolObjectList_A_input {
+  create(input: [AnnotatedWithAtProtocolObjectList_A_C]!): [AnnotatedWithAtProtocolObjectList_A]
+  delete(filter: [AnnotatedWithAtProtocolObjectList_A_filter]!): Int
+}
+
+input AnnotatedWithAtProtocolObjectList_A_orderBy {
+  id: SortDirection
+}
+
+type AnnotatedWithAtProtocolObjectList_input {
+  A: AnnotatedWithAtProtocolObjectList_A_input
+}
+
+type AnnotatedWithAtProtocolString {
+  A(filter: [AnnotatedWithAtProtocolString_A_filter], orderBy: [AnnotatedWithAtProtocolString_A_orderBy], skip: Int, top: Int): AnnotatedWithAtProtocolString_A_connection
+}
+
+type AnnotatedWithAtProtocolStringList {
+  A(filter: [AnnotatedWithAtProtocolStringList_A_filter], orderBy: [AnnotatedWithAtProtocolStringList_A_orderBy], skip: Int, top: Int): AnnotatedWithAtProtocolStringList_A_connection
+}
+
+type AnnotatedWithAtProtocolStringList_A {
+  id: ID
+}
+
+input AnnotatedWithAtProtocolStringList_A_C {
+  id: ID
+}
+
+type AnnotatedWithAtProtocolStringList_A_connection {
+  nodes: [AnnotatedWithAtProtocolStringList_A]
+  totalCount: Int
+}
+
+input AnnotatedWithAtProtocolStringList_A_filter {
+  id: [ID_filter]
+}
+
+type AnnotatedWithAtProtocolStringList_A_input {
+  create(input: [AnnotatedWithAtProtocolStringList_A_C]!): [AnnotatedWithAtProtocolStringList_A]
+  delete(filter: [AnnotatedWithAtProtocolStringList_A_filter]!): Int
+}
+
+input AnnotatedWithAtProtocolStringList_A_orderBy {
+  id: SortDirection
+}
+
+type AnnotatedWithAtProtocolStringList_input {
+  A: AnnotatedWithAtProtocolStringList_A_input
+}
+
+type AnnotatedWithAtProtocolString_A {
+  id: ID
+}
+
+input AnnotatedWithAtProtocolString_A_C {
+  id: ID
+}
+
+type AnnotatedWithAtProtocolString_A_connection {
+  nodes: [AnnotatedWithAtProtocolString_A]
+  totalCount: Int
+}
+
+input AnnotatedWithAtProtocolString_A_filter {
+  id: [ID_filter]
+}
+
+type AnnotatedWithAtProtocolString_A_input {
+  create(input: [AnnotatedWithAtProtocolString_A_C]!): [AnnotatedWithAtProtocolString_A]
+  delete(filter: [AnnotatedWithAtProtocolString_A_filter]!): Int
+}
+
+input AnnotatedWithAtProtocolString_A_orderBy {
+  id: SortDirection
+}
+
+type AnnotatedWithAtProtocolString_input {
+  A: AnnotatedWithAtProtocolString_A_input
+}
+
+input ID_filter {
+  eq: ID
+  ge: ID
+  gt: ID
+  le: ID
+  lt: ID
+  ne: [ID]
+}
+
+type Mutation {
+  AnnotatedWithAtGraphQL: AnnotatedWithAtGraphQL_input
+  AnnotatedWithAtProtocolObjectList: AnnotatedWithAtProtocolObjectList_input
+  AnnotatedWithAtProtocolString: AnnotatedWithAtProtocolString_input
+  AnnotatedWithAtProtocolStringList: AnnotatedWithAtProtocolStringList_input
+}
+
+type Query {
+  AnnotatedWithAtGraphQL: AnnotatedWithAtGraphQL
+  AnnotatedWithAtProtocolObjectList: AnnotatedWithAtProtocolObjectList
+  AnnotatedWithAtProtocolString: AnnotatedWithAtProtocolString
+  AnnotatedWithAtProtocolStringList: AnnotatedWithAtProtocolStringList
+}
+
+enum SortDirection {
+  asc
+  desc
+}

--- a/test/tests/annotations.test.js
+++ b/test/tests/annotations.test.js
@@ -26,6 +26,22 @@ describe('graphql - annotations', () => {
       expect(response.data.errors[0].message).toMatch(/^Cannot query field "NotAnnotated" on type "Query"\./)
     })
 
+    test('service annotated with non-GraphQL protocol is not served', async () => {
+      const query = gql`
+        {
+          AnnotatedWithNonGraphQL {
+            A {
+              nodes {
+                id
+              }
+            }
+          }
+        }
+      `
+      const response = await POST(path, { query })
+      expect(response.data.errors[0].message).toMatch(/^Cannot query field "AnnotatedWithNonGraphQL" on type "Query"\./)
+    })
+
     test('service annotated with @graphql is served at configured path', async () => {
       const query = gql`
         {

--- a/test/tests/annotations.test.js
+++ b/test/tests/annotations.test.js
@@ -26,6 +26,22 @@ describe('graphql - annotations', () => {
       expect(response.data.errors[0].message).toMatch(/^Cannot query field "NotAnnotated" on type "Query"\./)
     })
 
+    test('service annotated with "@protocol: \'none\'" is not served', async () => {
+      const query = gql`
+        {
+          AnnotatedWithAtProtocolNone {
+            A {
+              nodes {
+                id
+              }
+            }
+          }
+        }
+      `
+      const response = await POST(path, { query })
+      expect(response.data.errors[0].message).toMatch(/^Cannot query field "AnnotatedWithAtProtocolNone " on type "Query"\./)
+    })
+
     test('service annotated with non-GraphQL protocol is not served', async () => {
       const query = gql`
         {

--- a/test/tests/annotations.test.js
+++ b/test/tests/annotations.test.js
@@ -39,7 +39,7 @@ describe('graphql - annotations', () => {
         }
       `
       const response = await POST(path, { query })
-      expect(response.data.errors[0].message).toMatch(/^Cannot query field "AnnotatedWithAtProtocolNone " on type "Query"\./)
+      expect(response.data.errors[0].message).toMatch(/^Cannot query field "AnnotatedWithAtProtocolNone" on type "Query"\./)
     })
 
     test('service annotated with non-GraphQL protocol is not served', async () => {


### PR DESCRIPTION
When compiling services with `cds.compile.to.graphql` or `.to.gql` (API or CLI), only compile services with GraphQL protocol annotations (such as `@graphql` or `@protocol: 'graphql'`). 