### PR TITLE
chore: Remove prettier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint": "^8",
     "express": "^4.17.1",
     "jest": "^29.3.1",
-    "prettier": "3.2.4",
     "semver": "^7.4.0",
     "sqlite3": "^5.0.2"
   }


### PR DESCRIPTION
Prettier dependency is not required, prettier scripts use `npx`.