### PR TITLE
test: support decimals returned as strings by CDS query API

### DIFF
--- a/test/tests/types.test.js
+++ b/test/tests/types.test.js
@@ -433,7 +433,7 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Decimal is correctly parsed from input literal numeric string value', async () => {
         const number = 123.45
         const value = String(number)
-        const body = _getMutationForFieldWithLiteralValue(field, number, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
         const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })

--- a/test/tests/types.test.js
+++ b/test/tests/types.test.js
@@ -406,42 +406,45 @@ describe('graphql - types parsing and validation', () => {
 
     describe('input literal', () => {
       test('cds.Decimal is correctly parsed from input literal float value', async () => {
-        const value = 123.45
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
-        const data = { TypesService: { MyEntity: { create: [{ [field]: String(value) }] } } }
+        const number = 123.45
+        const value = String(number)
+        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(String(result[field])).toEqual(String(value))
+        expect(String(result[field])).toEqual(value)
       })
 
       test('cds.Decimal is correctly parsed from input literal int value', async () => {
-        const value = 123
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
-        const data = { TypesService: { MyEntity: { create: [{ [field]: String(value) }] } } }
+        const number = 123
+        const value = String(number)
+        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(String(result[field])).toEqual(String(value))
+        expect(String(result[field])).toEqual(value)
       })
 
       test('cds.Decimal is correctly parsed from input literal numeric string value', async () => {
-        const value = 123.45
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
-        const data = { TypesService: { MyEntity: { create: [{ [field]: String(value) }] } } }
+        const number = 123.45
+        const value = String(number)
+        const query = _getMutationForFieldWithLiteralValue(field, number, true)
+        const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(String(result[field])).toEqual(String(value))
+        expect(String(result[field])).toEqual(value)
       })
 
       test('cds.Decimal correctly determines large input literal numeric string to be a decimal number', async () => {
         const value = '12345678901234567890.01234567890123456789'
         const query = _getMutationForFieldWithLiteralValue(field, value, true)
-        const data = { TypesService: { MyEntity: { create: [{ [field]: String(value) }] } } }
+        const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
@@ -508,7 +511,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(String(result[field])).toEqual(String(value))
+        expect(String(result[field])).toEqual(value)
       })
 
       test('cds.Decimal is correctly parsed from variable string int value', async () => {
@@ -520,7 +523,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(String(result[field])).toEqual(String(value))
+        expect(String(result[field])).toEqual(value)
       })
 
       test('cds.Decimal correctly determines large numeric string variable to be a decimal number', async () => {
@@ -535,8 +538,8 @@ describe('graphql - types parsing and validation', () => {
       })
 
       test('cds.Decimal throws error when variable value is a float', async () => {
-        const value = 123.45
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const number = 123.45
+        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value 123.45 at "input.myDecimal"; Decimal variable value must be represented by a string: 123.45'
         const response = await POST('/graphql', { query, variables })
@@ -544,8 +547,8 @@ describe('graphql - types parsing and validation', () => {
       })
 
       test('cds.Decimal throws error when variable value is an int', async () => {
-        const value = 123
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const number = 123
+        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value 123 at "input.myDecimal"; Decimal variable value must be represented by a string: 123'
         const response = await POST('/graphql', { query, variables })
@@ -583,51 +586,52 @@ describe('graphql - types parsing and validation', () => {
 
   describe('cds.DecimalFloat', () => {
     const field = 'myDecimalFloat'
-    const value = 1234.567
+    const number = 1234.567
+    const value = String(number)
 
     test('cds.DecimalFloat is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, false)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(String(result[field])).toEqual(String(value))
+      expect(String(result[field])).toEqual(value)
     })
 
     test('cds.DecimalFloat is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(String(result[field])).toEqual(String(value))
+      expect(String(result[field])).toEqual(value)
     })
   })
 
   describe('cds.Double', () => {
     const field = 'myDouble'
-    const value = 1234.567
+    const number = 1234.567
 
     test('cds.Double is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, false)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(result[field]).toEqual(number)
     })
 
     test('cds.Double is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(result[field]).toEqual(number)
     })
   })
 
@@ -636,27 +640,27 @@ describe('graphql - types parsing and validation', () => {
 
     describe('input literal', () => {
       test('cds.Int16 is correctly parsed from input literal int value', async () => {
-        const value = 32767 // Max Int16
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
-        const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+        const number = 32767 // Max Int16
+        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(value)
+        expect(result[field]).toEqual(number)
       })
 
       test('cds.Int16 throws error when input literal int value exceeds max value', async () => {
-        const value = 32768 // Max Int16 + 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const number = 32768 // Max Int16 + 1
+        const query = _getMutationForFieldWithLiteralValue(field, number, false)
         const message = 'Int16 must be an integer value between -(2^15) and 2^15 - 1: 32768'
         const response = await POST('/graphql', { query })
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when input literal int value exceeds min value', async () => {
-        const value = -32769 // Min Int16 - 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const number = -32769 // Min Int16 - 1
+        const query = _getMutationForFieldWithLiteralValue(field, number, false)
         const message = 'Int16 must be an integer value between -(2^15) and 2^15 - 1: -32769'
         const response = await POST('/graphql', { query })
         expect(response.data.errors[0].message).toEqual(message)
@@ -689,19 +693,19 @@ describe('graphql - types parsing and validation', () => {
 
     describe('variable value', () => {
       test('cds.Int16 is correctly parsed from variable number value', async () => {
-        const value = 32767 // Max Int16
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
-        const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+        const number = 32767 // Max Int16
+        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+        const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(value)
+        expect(result[field]).toEqual(number)
       })
 
       test('cds.Int16 throws error when variable number value exceeds max value', async () => {
-        const value = 32768 // Max Int16 + 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const number = 32768 // Max Int16 + 1
+        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value 32768 at "input.myInt16"; Int16 must be an integer value between -(2^15) and 2^15 - 1: 32768'
         const response = await POST('/graphql', { query, variables })
@@ -709,8 +713,8 @@ describe('graphql - types parsing and validation', () => {
       })
 
       test('cds.Int16 throws error when variable number value exceeds min value', async () => {
-        const value = -32769 // Min Int16 - 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const number = -32769 // Min Int16 - 1
+        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value -32769 at "input.myInt16"; Int16 must be an integer value between -(2^15) and 2^15 - 1: -32769'
         const response = await POST('/graphql', { query, variables })
@@ -749,26 +753,26 @@ describe('graphql - types parsing and validation', () => {
   // Note: maps to same type as cds.Integer
   describe('cds.Int32', () => {
     const field = 'myInt32'
-    const value = 2147483647
+    const number = 2147483647
 
     test('cds.Int32 is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, false)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(result[field]).toEqual(number)
     })
 
     test('cds.Int32 is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(result[field]).toEqual(number)
     })
   })
 
@@ -801,26 +805,26 @@ describe('graphql - types parsing and validation', () => {
 
   describe('cds.Integer', () => {
     const field = 'myInteger'
-    const value = 2147483647
+    const number = 2147483647
 
     test('cds.Integer is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, false)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(result[field]).toEqual(number)
     })
 
     test('cds.Integer is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
-      const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
+      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(result[field]).toEqual(number)
     })
   })
 

--- a/test/tests/types.test.js
+++ b/test/tests/types.test.js
@@ -65,8 +65,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary is correctly parsed from input literal base64url encoded string value', async () => {
@@ -77,8 +77,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary is correctly parsed from input literal base64 encoded string value with padding', async () => {
@@ -89,8 +89,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary is correctly parsed from input literal base64 encoded string value with no padding', async () => {
@@ -101,8 +101,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary throws error when input literal is not a string, but an integer', async () => {
@@ -147,8 +147,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary is correctly parsed from variable base64url encoded string value', async () => {
@@ -159,8 +159,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary is correctly parsed from variable base64 encoded string value with padding', async () => {
@@ -171,8 +171,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary is correctly parsed from variable base64 encoded string value with no padding', async () => {
@@ -183,8 +183,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.Binary throws error when variable string value contains non base64 or base64url characters', async () => {
@@ -234,8 +234,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.Boolean is correctly parsed from variable value', async () => {
@@ -244,8 +244,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -260,8 +260,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Date throws error when input literal is a string containing a non-date value', async () => {
@@ -289,8 +289,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Date throws error when variable is a string containing a non-date value', async () => {
@@ -324,8 +324,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.DateTime is correctly parsed from input literal non-UTC datetime string value', async () => {
@@ -336,8 +336,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: returnValue })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: returnValue })
       })
 
       test('cds.DateTime throws error when input literal is a string containing a non-datetime value', async () => {
@@ -365,8 +365,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.DateTime is correctly parsed from variable non-UTC datetime string value', async () => {
@@ -377,8 +377,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: returnValue })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: returnValue })
       })
 
       test('cds.DateTime throws error when variable is a string containing a non-datetime value', async () => {
@@ -412,8 +412,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Decimal is correctly parsed from input literal int value', async () => {
@@ -423,8 +423,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Decimal is correctly parsed from input literal numeric string value', async () => {
@@ -434,8 +434,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Decimal correctly determines large input literal numeric string to be a decimal number', async () => {
@@ -445,9 +445,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result.length).toBe(1)
-        expect(result[0][field]).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result[field]).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
       })
 
       test('cds.Decimal throws error when input literal is not a decimal string, but a boolean', async () => {
@@ -508,8 +507,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: number })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: number })
       })
 
       test('cds.Decimal is correctly parsed from variable string int value', async () => {
@@ -520,8 +519,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: number })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: number })
       })
 
       test('cds.Decimal correctly determines large numeric string variable to be a decimal number', async () => {
@@ -531,9 +530,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result.length).toBe(1)
-        expect(result[0][field]).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result[field]).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
       })
 
       test('cds.Decimal throws error when variable value is a float', async () => {
@@ -593,8 +591,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.DecimalFloat is correctly parsed from variable value', async () => {
@@ -603,8 +601,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -618,8 +616,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.Double is correctly parsed from variable value', async () => {
@@ -628,8 +626,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -644,8 +642,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Int16 throws error when input literal int value exceeds max value', async () => {
@@ -697,8 +695,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Int16 throws error when variable number value exceeds max value', async () => {
@@ -759,8 +757,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.Int32 is correctly parsed from variable value', async () => {
@@ -769,8 +767,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -785,8 +783,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.Int64 is correctly parsed from variable string value', async () => {
@@ -796,8 +794,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -811,8 +809,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.Integer is correctly parsed from variable value', async () => {
@@ -821,8 +819,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -837,8 +835,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Integer64 throws error when input literal int value exceeds max value', async () => {
@@ -864,8 +862,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Integer64 throws error when input literal string value exceeds max value', async () => {
@@ -926,8 +924,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Integer64 throws error when variable string value exceeds max value', async () => {
@@ -993,8 +991,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.LargeBinary is correctly parsed from large input literal base64url encoded string value', async () => {
@@ -1004,8 +1002,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
     })
 
@@ -1017,8 +1015,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
 
       test('cds.LargeBinary is correctly parsed from large variable base64url encoded string value', async () => {
@@ -1028,8 +1026,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: buffer })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: buffer })
       })
     })
   })
@@ -1052,8 +1050,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.LargeString is correctly parsed from variable value', async () => {
@@ -1062,8 +1060,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -1077,8 +1075,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.String is correctly parsed from variable value', async () => {
@@ -1087,8 +1085,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 
@@ -1103,8 +1101,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Time throws error when input literal is a string containing an invalid time format value', async () => {
@@ -1140,8 +1138,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.Time throws error when variable is a string containing an invalid time format value', async () => {
@@ -1185,8 +1183,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: expect.stringMatching(returnValue) })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
       })
 
       test('cds.Timestamp is correctly parsed from input literal high precision timestamp string value', async () => {
@@ -1197,8 +1195,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: expect.stringMatching(returnValue) })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
       })
 
       test('cds.Timestamp throws error when input literal is a string containing a non-time value', async () => {
@@ -1228,8 +1226,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: expect.stringMatching(returnValue) })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
       })
 
       test('cds.Timestamp is correctly parsed from variable high precision timestamp string value', async () => {
@@ -1240,8 +1238,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: expect.stringMatching(returnValue) })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
       })
 
       test('cds.Timestamp throws error when variable is a string containing a non-timestamp value', async () => {
@@ -1275,8 +1273,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.UInt8 throws error when input literal int value exceeds max value', async () => {
@@ -1328,8 +1326,8 @@ describe('graphql - types parsing and validation', () => {
         const response = await POST('/graphql', { query, variables })
         expect(response.data).toEqual({ data })
 
-        const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toContainEqual({ [field]: value })
+        const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+        expect(result).toEqual({ [field]: value })
       })
 
       test('cds.UInt8 throws error when variable number value exceeds max value', async () => {
@@ -1389,8 +1387,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
 
     test('cds.UUID is correctly parsed from variable value', async () => {
@@ -1399,8 +1397,8 @@ describe('graphql - types parsing and validation', () => {
       const response = await POST('/graphql', { query, variables })
       expect(response.data).toEqual({ data })
 
-      const result = await SELECT.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toContainEqual({ [field]: value })
+      const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
+      expect(result).toEqual({ [field]: value })
     })
   })
 })

--- a/test/tests/types.test.js
+++ b/test/tests/types.test.js
@@ -66,7 +66,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary is correctly parsed from input literal base64url encoded string value', async () => {
@@ -78,7 +78,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary is correctly parsed from input literal base64 encoded string value with padding', async () => {
@@ -90,7 +90,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary is correctly parsed from input literal base64 encoded string value with no padding', async () => {
@@ -102,7 +102,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary throws error when input literal is not a string, but an integer', async () => {
@@ -148,7 +148,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary is correctly parsed from variable base64url encoded string value', async () => {
@@ -160,7 +160,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary is correctly parsed from variable base64 encoded string value with padding', async () => {
@@ -172,7 +172,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary is correctly parsed from variable base64 encoded string value with no padding', async () => {
@@ -184,7 +184,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.Binary throws error when variable string value contains non base64 or base64url characters', async () => {
@@ -235,7 +235,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.Boolean is correctly parsed from variable value', async () => {
@@ -245,7 +245,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -261,7 +261,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Date throws error when input literal is a string containing a non-date value', async () => {
@@ -290,7 +290,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Date throws error when variable is a string containing a non-date value', async () => {
@@ -325,7 +325,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.DateTime is correctly parsed from input literal non-UTC datetime string value', async () => {
@@ -337,7 +337,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: returnValue })
+        expect(result[field]).toEqual(returnValue)
       })
 
       test('cds.DateTime throws error when input literal is a string containing a non-datetime value', async () => {
@@ -366,7 +366,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.DateTime is correctly parsed from variable non-UTC datetime string value', async () => {
@@ -378,7 +378,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: returnValue })
+        expect(result[field]).toEqual(returnValue)
       })
 
       test('cds.DateTime throws error when variable is a string containing a non-datetime value', async () => {
@@ -413,7 +413,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Decimal is correctly parsed from input literal int value', async () => {
@@ -424,7 +424,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Decimal is correctly parsed from input literal numeric string value', async () => {
@@ -435,7 +435,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Decimal correctly determines large input literal numeric string to be a decimal number', async () => {
@@ -508,7 +508,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: number })
+        expect(result[field]).toEqual(number)
       })
 
       test('cds.Decimal is correctly parsed from variable string int value', async () => {
@@ -520,7 +520,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: number })
+        expect(result[field]).toEqual(number)
       })
 
       test('cds.Decimal correctly determines large numeric string variable to be a decimal number', async () => {
@@ -592,7 +592,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.DecimalFloat is correctly parsed from variable value', async () => {
@@ -602,7 +602,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -617,7 +617,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.Double is correctly parsed from variable value', async () => {
@@ -627,7 +627,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -643,7 +643,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Int16 throws error when input literal int value exceeds max value', async () => {
@@ -696,7 +696,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Int16 throws error when variable number value exceeds max value', async () => {
@@ -758,7 +758,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.Int32 is correctly parsed from variable value', async () => {
@@ -768,7 +768,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -784,7 +784,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.Int64 is correctly parsed from variable string value', async () => {
@@ -795,7 +795,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -810,7 +810,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.Integer is correctly parsed from variable value', async () => {
@@ -820,7 +820,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -836,7 +836,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Integer64 throws error when input literal int value exceeds max value', async () => {
@@ -863,7 +863,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Integer64 throws error when input literal string value exceeds max value', async () => {
@@ -925,7 +925,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Integer64 throws error when variable string value exceeds max value', async () => {
@@ -992,7 +992,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.LargeBinary is correctly parsed from large input literal base64url encoded string value', async () => {
@@ -1003,7 +1003,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
     })
 
@@ -1016,7 +1016,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
 
       test('cds.LargeBinary is correctly parsed from large variable base64url encoded string value', async () => {
@@ -1027,7 +1027,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: buffer })
+        expect(result[field]).toEqual(buffer)
       })
     })
   })
@@ -1051,7 +1051,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.LargeString is correctly parsed from variable value', async () => {
@@ -1061,7 +1061,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -1076,7 +1076,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.String is correctly parsed from variable value', async () => {
@@ -1086,7 +1086,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 
@@ -1102,7 +1102,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Time throws error when input literal is a string containing an invalid time format value', async () => {
@@ -1139,7 +1139,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.Time throws error when variable is a string containing an invalid time format value', async () => {
@@ -1184,7 +1184,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
+        expect(result[field]).toMatch(returnValue)
       })
 
       test('cds.Timestamp is correctly parsed from input literal high precision timestamp string value', async () => {
@@ -1196,7 +1196,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
+        expect(result[field]).toMatch(returnValue)
       })
 
       test('cds.Timestamp throws error when input literal is a string containing a non-time value', async () => {
@@ -1227,7 +1227,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
+        expect(result[field]).toMatch(returnValue)
       })
 
       test('cds.Timestamp is correctly parsed from variable high precision timestamp string value', async () => {
@@ -1239,7 +1239,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: expect.stringMatching(returnValue) })
+        expect(result[field]).toMatch(returnValue)
       })
 
       test('cds.Timestamp throws error when variable is a string containing a non-timestamp value', async () => {
@@ -1274,7 +1274,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.UInt8 throws error when input literal int value exceeds max value', async () => {
@@ -1327,7 +1327,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result).toEqual({ [field]: value })
+        expect(result[field]).toEqual(value)
       })
 
       test('cds.UInt8 throws error when variable number value exceeds max value', async () => {
@@ -1388,7 +1388,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
 
     test('cds.UUID is correctly parsed from variable value', async () => {
@@ -1398,7 +1398,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result).toEqual({ [field]: value })
+      expect(result[field]).toEqual(value)
     })
   })
 })

--- a/test/tests/types.test.js
+++ b/test/tests/types.test.js
@@ -9,8 +9,8 @@ const _getTestBuffer = repetitions => {
   return Buffer.from(string)
 }
 
-const _getMutationForFieldWithLiteralValue = (field, value, quoted) =>
-  gql`
+const _getMutationForFieldWithLiteralValue = (field, value, quoted) => ({
+  query: gql`
     mutation {
       TypesService {
         MyEntity {
@@ -21,6 +21,7 @@ const _getMutationForFieldWithLiteralValue = (field, value, quoted) =>
       }
     }
   `
+})
 
 const _getMutationAndVariablesForFieldWithVariable = (field, value) => ({
   query: gql`
@@ -60,9 +61,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from input literal base64 encoded string value', async () => {
         const buffer = _fileBuffer
         const value = _fileBuffer.toString('base64')
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: _toBase64Url(value) }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -72,9 +73,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from input literal base64url encoded string value', async () => {
         const buffer = _fileBuffer
         const value = _toBase64Url(_fileBuffer.toString('base64'))
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -84,9 +85,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from input literal base64 encoded string value with padding', async () => {
         const buffer = Buffer.from('This is a test string!')
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ=='
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -96,9 +97,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from input literal base64 encoded string value with no padding', async () => {
         const buffer = Buffer.from('This is a test string!')
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ==' }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -107,33 +108,33 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Binary throws error when input literal is not a string, but an integer', async () => {
         const value = 123
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Binary cannot represent non string value: 123'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Binary throws error when input literal string value contains non base64 or base64url characters', async () => {
         const value = 'abc.def~123'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Binary values must be base64 or base64url encoded and normalized strings'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Binary throws error when input literal string value contains non-normalized base64 encoding', async () => {
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nISF=' // Should be E=
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Binary values must be base64 or base64url encoded and normalized strings'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Binary throws error when input literal string value contains base64 encoded string value with excessive padding', async () => {
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ=========='
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Binary values must be base64 or base64url encoded and normalized strings'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -142,9 +143,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from variable base64 encoded string value', async () => {
         const buffer = _fileBuffer
         const value = _fileBuffer.toString('base64')
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: _toBase64Url(value) }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -154,9 +155,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from variable base64url encoded string value', async () => {
         const buffer = _fileBuffer
         const value = _toBase64Url(_fileBuffer.toString('base64'))
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -166,9 +167,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from variable base64 encoded string value with padding', async () => {
         const buffer = Buffer.from('This is a test string!')
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ=='
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -178,9 +179,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Binary is correctly parsed from variable base64 encoded string value with no padding', async () => {
         const buffer = Buffer.from('This is a test string!')
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ==' }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -189,36 +190,36 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Binary throws error when variable string value contains non base64 or base64url characters', async () => {
         const value = 'abc.def~123'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "abc.def~123" at "input.myBinary"; Binary values must be base64 or base64url encoded and normalized strings'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Binary throws error when variable value is not a string, but an integer', async () => {
         const value = 123
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 123 at "input.myBinary"; Binary cannot represent non string value: 123'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Binary throws error when variable string value contains non-normalized base64 encoding', async () => {
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nISF=' // Should be E=
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Binary values must be base64 or base64url encoded and normalized strings'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Binary throws error when variable string value contains base64 encoded string value with excessive padding', async () => {
         const value = 'VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ=========='
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "VGhpcyBpcyBhIHRlc3Qgc3RyaW5nIQ==========" at "input.myBinary"; Binary values must be base64 or base64url encoded and normalized strings'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -229,9 +230,9 @@ describe('graphql - types parsing and validation', () => {
     const value = true
 
     test('cds.Boolean is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, false)
+      const body = _getMutationForFieldWithLiteralValue(field, value, false)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -239,9 +240,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.Boolean is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, value)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -255,9 +256,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.Date is correctly parsed from input literal string value', async () => {
         const value = '2021-06-27'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -266,17 +267,17 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Date throws error when input literal is a string containing a non-date value', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Date values must be strings in the ISO 8601 format YYYY-MM-DD: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Date throws error when input literal is not a string, but an integer', async () => {
         const value = 20210627
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Date cannot represent non string value: 20210627'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -284,9 +285,9 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.Date is correctly parsed from variable string value', async () => {
         const value = '2021-06-27'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -295,19 +296,19 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Date throws error when variable is a string containing a non-date value', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myDate"; Date values must be strings in the ISO 8601 format YYYY-MM-DD: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Date throws error when variable value is not a string, but an integer', async () => {
         const value = 20210627
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 20210627 at "input.myDate"; Date cannot represent non string value: 20210627'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -319,9 +320,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.DateTime is correctly parsed from input literal UTC datetime string value', async () => {
         const value = '2021-06-27T14:52:23Z'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -331,9 +332,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.DateTime is correctly parsed from input literal non-UTC datetime string value', async () => {
         const value = '2021-06-27T14:52:23+12:34'
         const returnValue = '2021-06-27T02:18:23Z'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: returnValue }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -342,17 +343,17 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.DateTime throws error when input literal is a string containing a non-datetime value', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'DateTime values must be strings in the ISO 8601 format YYYY-MM-DDThh-mm-ssTZD: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.DateTime throws error when input literal is not a string, but an integer', async () => {
         const value = 20210627145223
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'DateTime cannot represent non string value: 20210627145223'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -360,9 +361,9 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.DateTime is correctly parsed from variable UTC datetime string value', async () => {
         const value = '2021-06-27T14:52:23Z'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -372,9 +373,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.DateTime is correctly parsed from variable non-UTC datetime string value', async () => {
         const value = '2021-06-27T14:52:23+12:34'
         const returnValue = '2021-06-27T02:18:23Z'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: returnValue }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -383,19 +384,19 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.DateTime throws error when variable is a string containing a non-datetime value', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myDateTime"; DateTime values must be strings in the ISO 8601 format YYYY-MM-DDThh-mm-ssTZD: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.DateTime throws error when variable value is not a string, but an integer', async () => {
         const value = 20210627145223
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 20210627145223 at "input.myDateTime"; DateTime cannot represent non string value: 20210627145223'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -408,9 +409,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Decimal is correctly parsed from input literal float value', async () => {
         const number = 123.45
         const value = String(number)
-        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const body = _getMutationForFieldWithLiteralValue(field, number, false)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -420,9 +421,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Decimal is correctly parsed from input literal int value', async () => {
         const number = 123
         const value = String(number)
-        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const body = _getMutationForFieldWithLiteralValue(field, number, false)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -432,9 +433,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Decimal is correctly parsed from input literal numeric string value', async () => {
         const number = 123.45
         const value = String(number)
-        const query = _getMutationForFieldWithLiteralValue(field, number, true)
+        const body = _getMutationForFieldWithLiteralValue(field, number, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -443,9 +444,9 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Decimal correctly determines large input literal numeric string to be a decimal number', async () => {
         const value = '12345678901234567890.01234567890123456789'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -454,49 +455,49 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Decimal throws error when input literal is not a decimal string, but a boolean', async () => {
         const value = false
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Decimal must be a numeric value: false'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when input literal is non-numeric string value', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Decimal must be a numeric value: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when input literal contains non-numeric character embedded in numeric string value', async () => {
         const value = '123.450000000000000000a'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Decimal must be a numeric value: "123.450000000000000000a"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when input literal is a whitespace string', async () => {
         const value = ' '
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Decimal must be a numeric value: " "'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when input literal is a string containing NaN', async () => {
         const value = 'NaN'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Decimal must be a numeric value: "NaN"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when input literal is a string containing Infinity', async () => {
         const value = 'Infinity'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Decimal must be a numeric value: "Infinity"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -505,9 +506,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Decimal is correctly parsed from variable string float value', async () => {
         const number = 123.45
         const value = String(number)
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -517,9 +518,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Decimal is correctly parsed from variable string int value', async () => {
         const number = 123
         const value = String(number)
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -528,9 +529,9 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Decimal correctly determines large numeric string variable to be a decimal number', async () => {
         const value = '12345678901234567890.01234567890123456789'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -539,46 +540,46 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Decimal throws error when variable value is a float', async () => {
         const number = 123.45
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value 123.45 at "input.myDecimal"; Decimal variable value must be represented by a string: 123.45'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when variable value is an int', async () => {
         const number = 123
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value 123 at "input.myDecimal"; Decimal variable value must be represented by a string: 123'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when variable value is a whitespace string', async () => {
         const value = ' '
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value " " at "input.myDecimal"; Decimal must be a numeric value: " "'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when variable value is a string containing NaN', async () => {
         const value = 'NaN'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "NaN" at "input.myDecimal"; Decimal must be a numeric value: "NaN"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Decimal throws error when variable value is a string containing Infinity', async () => {
         const value = 'Infinity'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "Infinity" at "input.myDecimal"; Decimal must be a numeric value: "Infinity"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -590,9 +591,9 @@ describe('graphql - types parsing and validation', () => {
     const value = String(number)
 
     test('cds.DecimalFloat is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const body = _getMutationForFieldWithLiteralValue(field, number, false)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -600,9 +601,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.DecimalFloat is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, number)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -615,9 +616,9 @@ describe('graphql - types parsing and validation', () => {
     const number = 1234.567
 
     test('cds.Double is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const body = _getMutationForFieldWithLiteralValue(field, number, false)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -625,9 +626,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.Double is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, number)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -641,9 +642,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.Int16 is correctly parsed from input literal int value', async () => {
         const number = 32767 // Max Int16
-        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const body = _getMutationForFieldWithLiteralValue(field, number, false)
         const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -652,41 +653,41 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Int16 throws error when input literal int value exceeds max value', async () => {
         const number = 32768 // Max Int16 + 1
-        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const body = _getMutationForFieldWithLiteralValue(field, number, false)
         const message = 'Int16 must be an integer value between -(2^15) and 2^15 - 1: 32768'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when input literal int value exceeds min value', async () => {
         const number = -32769 // Min Int16 - 1
-        const query = _getMutationForFieldWithLiteralValue(field, number, false)
+        const body = _getMutationForFieldWithLiteralValue(field, number, false)
         const message = 'Int16 must be an integer value between -(2^15) and 2^15 - 1: -32769'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when input literal is not a number, but a numeric string', async () => {
         const value = '12345'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Int16 cannot represent non integer value: "12345"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when input literal is not a number, but a non-numeric string', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Int16 cannot represent non integer value: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when input literal is not a number, but a boolean', async () => {
         const value = false
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Int16 cannot represent non integer value: false'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -694,9 +695,9 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.Int16 is correctly parsed from variable number value', async () => {
         const number = 32767 // Max Int16
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, number)
         const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -705,46 +706,46 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Int16 throws error when variable number value exceeds max value', async () => {
         const number = 32768 // Max Int16 + 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value 32768 at "input.myInt16"; Int16 must be an integer value between -(2^15) and 2^15 - 1: 32768'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when variable number value exceeds min value', async () => {
         const number = -32769 // Min Int16 - 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, number)
         const message =
           'Variable "$input" got invalid value -32769 at "input.myInt16"; Int16 must be an integer value between -(2^15) and 2^15 - 1: -32769'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when variable value is not a number, but a numeric string', async () => {
         const value = '12345'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "12345" at "input.myInt16"; Int16 cannot represent non integer value: "12345"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when variable value is not a number, but a non-numeric string', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myInt16"; Int16 cannot represent non integer value: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Int16 throws error when variable value is not a number, but a boolean', async () => {
         const value = false
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value false at "input.myInt16"; Int16 cannot represent non integer value: false'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -756,9 +757,9 @@ describe('graphql - types parsing and validation', () => {
     const number = 2147483647
 
     test('cds.Int32 is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const body = _getMutationForFieldWithLiteralValue(field, number, false)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -766,9 +767,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.Int32 is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, number)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -782,9 +783,9 @@ describe('graphql - types parsing and validation', () => {
 
     test('cds.Int64 is correctly parsed from input literal int value', async () => {
       const value = '999999999999999' // Max Int64 = 9223372036854775807, but lower due to SQLite rounding errors
-      const query = _getMutationForFieldWithLiteralValue(field, value, false)
+      const body = _getMutationForFieldWithLiteralValue(field, value, false)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -793,9 +794,9 @@ describe('graphql - types parsing and validation', () => {
 
     test('cds.Int64 is correctly parsed from variable string value', async () => {
       const value = '999999999999999' // Max Int64 = 9223372036854775807, but lower due to SQLite rounding errors
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, value)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -808,9 +809,9 @@ describe('graphql - types parsing and validation', () => {
     const number = 2147483647
 
     test('cds.Integer is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, number, false)
+      const body = _getMutationForFieldWithLiteralValue(field, number, false)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -818,9 +819,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.Integer is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, number)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, number)
       const data = { TypesService: { MyEntity: { create: [{ [field]: number }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -834,9 +835,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.Integer64 is correctly parsed from input literal int value', async () => {
         const value = '999999999999999' // Max Integer64 = 9223372036854775807, but lower due to SQLite rounding errors
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -845,25 +846,25 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Integer64 throws error when input literal int value exceeds max value', async () => {
         const value = '9223372036854775808' // Max Integer64 + 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Int64 must be an integer value between -(2^63) and 2^63 - 1: 9223372036854775808'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when input literal int value exceeds min value', async () => {
         const value = '-9223372036854775809' // Min Integer64 - 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Int64 must be an integer value between -(2^63) and 2^63 - 1: -9223372036854775809'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 is correctly parsed from input literal numeric string value', async () => {
         const value = '999999999999999' // Max Integer64 = 9223372036854775807, but lower due to SQLite rounding errors
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -872,41 +873,41 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Integer64 throws error when input literal string value exceeds max value', async () => {
         const value = '9223372036854775808' // Max Integer64 + 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Int64 must be an integer value between -(2^63) and 2^63 - 1: "9223372036854775808"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when input literal string value exceeds min value', async () => {
         const value = '-9223372036854775809' // Min Integer64 - 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Int64 must be an integer value between -(2^63) and 2^63 - 1: "-9223372036854775809"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when input literal is not a number, but a non-numeric string', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Int64 cannot represent non integer value: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when input literal is not a number, but a whitespace string', async () => {
         const value = ' '
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Int64 cannot represent non integer value: " "'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when input literal is not a number, but a boolean', async () => {
         const value = false
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Int64 cannot represent non integer value: false'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -914,18 +915,18 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.Integer64 throws error when variable value is a number, due to potential rounding errors', async () => {
         const value = 123
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 123 at "input.myInteger64"; Int64 variable value must be represented by a string: 123'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 is correctly parsed from variable string value', async () => {
         const value = '999999999999999' // Max Integer64 = 9223372036854775807, but lower due to SQLite rounding errors
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -934,46 +935,46 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Integer64 throws error when variable string value exceeds max value', async () => {
         const value = '9223372036854775808' // Max Integer64 + 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "9223372036854775808" at "input.myInteger64"; Int64 must be an integer value between -(2^63) and 2^63 - 1: 9223372036854775808'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when variable string value exceeds min value', async () => {
         const value = '-9223372036854775809' // Min Integer64 - 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "-9223372036854775809" at "input.myInteger64"; Int64 must be an integer value between -(2^63) and 2^63 - 1: -9223372036854775809'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when variable value is not a number, but a non-numeric string', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myInteger64"; Int64 cannot represent non integer value: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when variable value is not a number, but a whitespace string', async () => {
         const value = ' '
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value " " at "input.myInteger64"; Int64 cannot represent non integer value: " "'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Integer64 throws error when variable value is not a number, but a boolean', async () => {
         const value = false
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value false at "input.myInteger64"; Int64 variable value must be represented by a string: false'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -990,9 +991,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.LargeBinary is correctly parsed from large input literal base64 encoded string value', async () => {
         const value = buffer.toString('base64')
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: _toBase64Url(value) }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1001,9 +1002,9 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.LargeBinary is correctly parsed from large input literal base64url encoded string value', async () => {
         const value = _toBase64Url(buffer.toString('base64'))
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1014,9 +1015,9 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.LargeBinary is correctly parsed from large variable base64 encoded string value', async () => {
         const value = buffer.toString('base64')
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: _toBase64Url(value) }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1025,9 +1026,9 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.LargeBinary is correctly parsed from large variable base64url encoded string value', async () => {
         const value = _toBase64Url(buffer.toString('base64'))
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1049,9 +1050,9 @@ describe('graphql - types parsing and validation', () => {
     })()
 
     test('cds.LargeString is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, true)
+      const body = _getMutationForFieldWithLiteralValue(field, value, true)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1059,9 +1060,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.LargeString is correctly parsed from variable value', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, true)
+      const body = _getMutationForFieldWithLiteralValue(field, value, true)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1074,9 +1075,9 @@ describe('graphql - types parsing and validation', () => {
     const value = 'This is a test string'
 
     test('cds.String is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, true)
+      const body = _getMutationForFieldWithLiteralValue(field, value, true)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1084,9 +1085,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.String is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, value)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1100,9 +1101,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.Time is correctly parsed from input literal string value', async () => {
         const value = '07:59:59'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1111,25 +1112,25 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Time throws error when input literal is a string containing an invalid time format value', async () => {
         const value = '99:99:99'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Time values must be strings in the ISO 8601 format hh:mm:ss: "99:99:99"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Time throws error when input literal is a string containing a non-time value', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'Time values must be strings in the ISO 8601 format hh:mm:ss: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Time throws error when input literal is not a string, but an integer', async () => {
         const value = 123456
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Time cannot represent non string value: 123456'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -1137,9 +1138,9 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.Time is correctly parsed from variable string value', async () => {
         const value = '07:59:59'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1148,28 +1149,28 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Time throws error when variable is a string containing an invalid time format value', async () => {
         const value = '99:99:99'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "99:99:99" at "input.myTime"; Time values must be strings in the ISO 8601 format hh:mm:ss: "99:99:99"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Time throws error when variable is a string containing a non-time value', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myTime"; Time values must be strings in the ISO 8601 format hh:mm:ss: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Time throws error when variable value is not a string, but an integer', async () => {
         const value = 123456
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 123456 at "input.myTime"; Time cannot represent non string value: 123456'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -1182,9 +1183,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Timestamp is correctly parsed from input literal timestamp string value', async () => {
         const value = '2021-06-27T14:52:23.123Z'
         const returnValue = /2021-06-27T14:52:23\.123(0000)?Z/ // timestamp precision increase with cds^7
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: expect.stringMatching(returnValue) }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1194,9 +1195,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Timestamp is correctly parsed from input literal high precision timestamp string value', async () => {
         const value = '2021-06-27T14:52:23.1234567Z'
         const returnValue = /2021-06-27T14:52:23\.123(4567)?Z/ // timestamp precision increase with cds^7
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const data = { TypesService: { MyEntity: { create: [{ [field]: expect.stringMatching(returnValue) }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1205,18 +1206,18 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Timestamp throws error when input literal is a string containing a non-time value', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message =
           'Timestamp values must be strings in the ISO 8601 format YYYY-MM-DDThh-mm-ss.sTZD with up to 7 digits of fractional seconds: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Timestamp throws error when input literal is not a string, but an integer', async () => {
         const value = 123456
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'Timestamp cannot represent non string value: 123456'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -1225,9 +1226,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Timestamp is correctly parsed from variable timestamp string value', async () => {
         const value = '2021-06-27T14:52:23.123Z'
         const returnValue = /2021-06-27T14:52:23\.123(0000)?Z/ // timestamp precision increase with cds^7
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: expect.stringMatching(returnValue) }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1237,9 +1238,9 @@ describe('graphql - types parsing and validation', () => {
       test('cds.Timestamp is correctly parsed from variable high precision timestamp string value', async () => {
         const value = '2021-06-27T14:52:23.1234567Z'
         const returnValue = /2021-06-27T14:52:23\.123(4567)?Z/ // timestamp precision increase with cds^7
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: expect.stringMatching(returnValue) }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1248,19 +1249,19 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.Timestamp throws error when variable is a string containing a non-timestamp value', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myTimestamp"; Timestamp values must be strings in the ISO 8601 format YYYY-MM-DDThh-mm-ss.sTZD with up to 7 digits of fractional seconds: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.Timestamp throws error when variable value is not a string, but an integer', async () => {
         const value = 123456
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 123456 at "input.myTimestamp"; Timestamp cannot represent non string value: 123456'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -1272,9 +1273,9 @@ describe('graphql - types parsing and validation', () => {
     describe('input literal', () => {
       test('cds.UInt8 is correctly parsed from input literal int value', async () => {
         const value = 255 // Max UInt8
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1283,41 +1284,41 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.UInt8 throws error when input literal int value exceeds max value', async () => {
         const value = 256 // Max UInt8 + 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'UInt8 must be an integer value between 0 and 2^8 - 1: 256'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when input literal int value exceeds min value', async () => {
         const value = -1 // Min UInt8 - 1
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'UInt8 must be an integer value between 0 and 2^8 - 1: -1'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when input literal is not a number, but a numeric string', async () => {
         const value = '123'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'UInt8 cannot represent non integer value: "123"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when input literal is not a number, but a non-numeric string', async () => {
         const value = 'bla'
-        const query = _getMutationForFieldWithLiteralValue(field, value, true)
+        const body = _getMutationForFieldWithLiteralValue(field, value, true)
         const message = 'UInt8 cannot represent non integer value: "bla"'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when input literal is not a number, but a boolean', async () => {
         const value = false
-        const query = _getMutationForFieldWithLiteralValue(field, value, false)
+        const body = _getMutationForFieldWithLiteralValue(field, value, false)
         const message = 'UInt8 cannot represent non integer value: false'
-        const response = await POST('/graphql', { query })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -1325,9 +1326,9 @@ describe('graphql - types parsing and validation', () => {
     describe('variable value', () => {
       test('cds.UInt8 is correctly parsed from variable number value', async () => {
         const value = 255 // Max UInt8
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1336,46 +1337,46 @@ describe('graphql - types parsing and validation', () => {
 
       test('cds.UInt8 throws error when variable number value exceeds max value', async () => {
         const value = 256 // Max UInt8 + 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value 256 at "input.myUInt8"; UInt8 must be an integer value between 0 and 2^8 - 1: 256'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when variable number value exceeds min value', async () => {
         const value = -1 // Min UInt8 - 1
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value -1 at "input.myUInt8"; UInt8 must be an integer value between 0 and 2^8 - 1: -1'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when variable value is not a number, but a numeric string', async () => {
         const value = '123'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "123" at "input.myUInt8"; UInt8 cannot represent non integer value: "123"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when variable value is not a number, but a non-numeric string', async () => {
         const value = 'bla'
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value "bla" at "input.myUInt8"; UInt8 cannot represent non integer value: "bla"'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
 
       test('cds.UInt8 throws error when variable value is not a number, but a boolean', async () => {
         const value = false
-        const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+        const body = _getMutationAndVariablesForFieldWithVariable(field, value)
         const message =
           'Variable "$input" got invalid value false at "input.myUInt8"; UInt8 cannot represent non integer value: false'
-        const response = await POST('/graphql', { query, variables })
+        const response = await POST('/graphql', body)
         expect(response.data.errors[0].message).toEqual(message)
       })
     })
@@ -1386,9 +1387,9 @@ describe('graphql - types parsing and validation', () => {
     const value = 'a94f80eb-0a8e-4a12-b02f-0c1747200bf0'
 
     test('cds.UUID is correctly parsed from input literal', async () => {
-      const query = _getMutationForFieldWithLiteralValue(field, value, true)
+      const body = _getMutationForFieldWithLiteralValue(field, value, true)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
@@ -1396,9 +1397,9 @@ describe('graphql - types parsing and validation', () => {
     })
 
     test('cds.UUID is correctly parsed from variable value', async () => {
-      const { query, variables } = _getMutationAndVariablesForFieldWithVariable(field, value)
+      const body = _getMutationAndVariablesForFieldWithVariable(field, value)
       const data = { TypesService: { MyEntity: { create: [{ [field]: value }] } } }
-      const response = await POST('/graphql', { query, variables })
+      const response = await POST('/graphql', body)
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)

--- a/test/tests/types.test.js
+++ b/test/tests/types.test.js
@@ -413,7 +413,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(value)
+        expect(String(result[field])).toEqual(String(value))
       })
 
       test('cds.Decimal is correctly parsed from input literal int value', async () => {
@@ -424,7 +424,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(value)
+        expect(String(result[field])).toEqual(String(value))
       })
 
       test('cds.Decimal is correctly parsed from input literal numeric string value', async () => {
@@ -435,7 +435,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(value)
+        expect(String(result[field])).toEqual(String(value))
       })
 
       test('cds.Decimal correctly determines large input literal numeric string to be a decimal number', async () => {
@@ -446,7 +446,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
+        expect(parseFloat(result[field])).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
       })
 
       test('cds.Decimal throws error when input literal is not a decimal string, but a boolean', async () => {
@@ -508,7 +508,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(number)
+        expect(String(result[field])).toEqual(String(value))
       })
 
       test('cds.Decimal is correctly parsed from variable string int value', async () => {
@@ -520,7 +520,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toEqual(number)
+        expect(String(result[field])).toEqual(String(value))
       })
 
       test('cds.Decimal correctly determines large numeric string variable to be a decimal number', async () => {
@@ -531,7 +531,7 @@ describe('graphql - types parsing and validation', () => {
         expect(response.data).toEqual({ data })
 
         const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-        expect(result[field]).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
+        expect(parseFloat(result[field])).toBeGreaterThan(12345678901234560000) // Incorrect sqlite value due to dynamic typing system and rounding errors
       })
 
       test('cds.Decimal throws error when variable value is a float', async () => {
@@ -592,7 +592,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(String(result[field])).toEqual(String(value))
     })
 
     test('cds.DecimalFloat is correctly parsed from variable value', async () => {
@@ -602,7 +602,7 @@ describe('graphql - types parsing and validation', () => {
       expect(response.data).toEqual({ data })
 
       const result = await SELECT.one.from('sap.cds.graphql.types.MyEntity').columns(field)
-      expect(result[field]).toEqual(value)
+      expect(String(result[field])).toEqual(String(value))
     })
   })
 


### PR DESCRIPTION
This PR also refactors unrelated tests. See this commit for actual relevant change: https://github.com/cap-js/graphql/commit/91615c5c85dd199c896bce7886e634e406411e24 (Results of CDS queries are cast to strings and compared to decimal values that are also cast to strings.)