### PR TITLE
refactor: Use node:timers/promises/setTimeout

### DIFF
--- a/test/resources/concurrency/srv/concurrency.js
+++ b/test/resources/concurrency/srv/concurrency.js
@@ -1,7 +1,6 @@
 
 const cds = require('@sap/cds')
-const util = require('util')
-const sleep = util.promisify(setTimeout)
+const sleep = require('node:timers/promises').setTimeout
 
 class ConcurrencyService extends cds.ApplicationService { init(){
 

--- a/test/resources/concurrency/srv/data-and-errors.js
+++ b/test/resources/concurrency/srv/data-and-errors.js
@@ -1,7 +1,6 @@
 
 const cds = require('@sap/cds')
-const util = require('util')
-const sleep = util.promisify(setTimeout)
+const sleep = require('node:timers/promises').setTimeout
 
 class DataAndErrorsService extends cds.ApplicationService { init(){
 


### PR DESCRIPTION
Refactoring to use `require('node:timers/promises').setTimeout` rather than `require('util').promisify(setTimeout)`.

No need to promisify a function as there's a native promise version of that: [Timers Promises API](https://nodejs.org/api/timers.html#timerspromisessettimeoutdelay-value-options)