### PR TITLE
chore: adapt license entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "GraphQL"
   ],
   "author": "SAP SE (https://www.sap.com)",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "repository": "cap-js/graphql",
   "homepage": "https://cap.cloud.sap/",
   "main": "index.js",


### PR DESCRIPTION
Replaces the placeholder value "SEE LICENSE IN LICENSE" with "Apache-2.0" as the project is licensed under Apache 2.0, and the LICENSE file contains the full license text.