### PR TITLE
fix: Mocked req objects should support req.get(header)

### DIFF
--- a/lib/resolvers/error.js
+++ b/lib/resolvers/error.js
@@ -59,7 +59,7 @@ const _clone = obj => Object.create(Object.getPrototypeOf(obj), Object.getOwnPro
 // TODO: Revise this logging functionality, as it's not specific to protocol adapters.
 // This function should be relocated and/or cleaned up when the new abstract/generic
 // protocol adapter is designed and implemented.
-const _log = error => {
+const _log = (error, req) => {
   // log errors and warnings only
   if (LOG_CDS.level <= cds.log.levels.WARN) return
 
@@ -76,7 +76,7 @@ const _log = error => {
     delete error2log.stack
   }
 
-  error2log = normalizeError(error2log, { locale: '', get(){} }, false)
+  error2log = normalizeError(error2log, { __proto__: req, locale: '' }, false)
 
   // determine if the status code represents a client error (4xx range)
   if (error2log.status >= 400 && error2log.status < 500) {
@@ -91,7 +91,7 @@ const _ensureError = error => (error instanceof Error ? error : new Error(error)
 
 const handleCDSError = (context, error) => {
   error = _ensureError(error)
-  _log(error)
+  _log(error, context.req)
   return _cdsToGraphQLError(context, error)
 }
 

--- a/lib/resolvers/error.js
+++ b/lib/resolvers/error.js
@@ -76,7 +76,7 @@ const _log = error => {
     delete error2log.stack
   }
 
-  error2log = normalizeError(error2log, { locale: '' }, false)
+  error2log = normalizeError(error2log, { locale: '', get(){} }, false)
 
   // determine if the status code represents a client error (4xx range)
   if (error2log.status >= 400 && error2log.status < 500) {


### PR DESCRIPTION
Using such mocked `req` objects is pretty bad practice, as it makes assumptions about internal implementations not using any of the public API features from Node.js and express. → please merge and publish that asap to unblock us for upcoming releases of `@sap/cds`