### PR TITLE
fix(logging): sanitization if literal values contain parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sanitization of logged queries, when running in production, if literal values contain parentheses
 - Read GraphiQL HTML file only once on startup, and only if GraphiQL is enabled, to avoid unnecessary file system access
 
 ### Removed

--- a/lib/GraphQLAdapter.js
+++ b/lib/GraphQLAdapter.js
@@ -19,9 +19,7 @@ function GraphQLAdapter(options) {
     ? require(path.join(cds.root, options.errorFormatter))
     : defaultErrorFormatter
 
-  router
-    .use(express.json({ ...cds.env.server.body_parser })) //> required by logger below
-    .use(queryLogger)
+  router.use(queryLogger)
 
   if (options.graphiql) router.use(graphiql)
 

--- a/lib/GraphQLAdapter.js
+++ b/lib/GraphQLAdapter.js
@@ -22,7 +22,7 @@ function GraphQLAdapter(options) {
   const router = express.Router()
 
   router.use(queryLogger)
-  if (options.graphiql) router.use(graphiql)
+  if (options.graphiql) router.use(require('../app/graphiql'))
   router.use(queryHandler)
 
   return router

--- a/lib/GraphQLAdapter.js
+++ b/lib/GraphQLAdapter.js
@@ -9,23 +9,22 @@ const { createHandler } = require('graphql-http/lib/use/express')
 const { formatError } = require('./resolvers/error')
 
 function GraphQLAdapter(options) {
-  const router = express.Router()
-  const { services } = options
   const defaults = { graphiql: true }
-  const schema = generateSchema4(services)
   options = { ...defaults, ...options }
 
   const errorFormatter = options.errorFormatter
     ? require(path.join(cds.root, options.errorFormatter))
     : defaultErrorFormatter
 
-  router.use(queryLogger)
+  const schema = generateSchema4(options.services)
 
-  if (options.graphiql) router.use(graphiql)
-
-  router.use((req, res) =>
+  const queryHandler = (req, res) =>
     createHandler({ schema, context: { req, res, errorFormatter }, formatError, ...options })(req, res)
-  )
+
+  const router = express.Router()
+  router.use(queryLogger)
+  if (options.graphiql) router.use(graphiql)
+  router.use(queryHandler)
 
   return router
 }

--- a/lib/GraphQLAdapter.js
+++ b/lib/GraphQLAdapter.js
@@ -22,6 +22,7 @@ function GraphQLAdapter(options) {
     createHandler({ schema, context: { req, res, errorFormatter }, formatError, ...options })(req, res)
 
   const router = express.Router()
+
   router.use(queryLogger)
   if (options.graphiql) router.use(graphiql)
   router.use(queryHandler)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,6 +6,25 @@ const LOG = cds.log('graphql')
 
 const _isEmptyObject = o => Object.keys(o).length === 0
 
+const _sanitizeArguments = query => {
+  let result = ''
+  let depth = 0
+
+  for (const char of query) {
+    if (char === '(') {
+      if (depth === 0) result += '( '
+      depth++
+    } else if (char === ')') {
+      depth--
+      if (depth === 0) result += '*** )'
+    } else {
+      if (depth === 0) result += char
+    }
+  }
+
+  return result
+}
+
 const queryLogger = (req, _, next) => {
   let query = req.body?.query || (req.query.query && decodeURIComponent(req.query.query))
   // Only log requests that contain a query
@@ -41,7 +60,7 @@ const queryLogger = (req, _, next) => {
   // If query is multiline string, add newline padding to front
   let formattedQuery = query.includes('\n') ? `\n${query}` : query
   // Sanitize all values between parentheses
-  if (IS_PRODUCTION) formattedQuery = formattedQuery.replace(/\([\s\S]*?\)/g, '( *** )')
+  if (IS_PRODUCTION) formattedQuery = _sanitizeArguments(formattedQuery)
 
   // Don't log undefined values
   LOG.info(...[req.method, formattedQueryInfo, formattedQuery].filter(e => e))

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,25 +6,6 @@ const LOG = cds.log('graphql')
 
 const _isEmptyObject = o => Object.keys(o).length === 0
 
-const _sanitizeArguments = query => {
-  let result = ''
-  let depth = 0
-
-  for (const char of query) {
-    if (char === '(') {
-      if (depth === 0) result += '( '
-      depth++
-    } else if (char === ')') {
-      depth--
-      if (depth === 0) result += '*** )'
-    } else {
-      if (depth === 0) result += char
-    }
-  }
-
-  return result
-}
-
 const queryLogger = (req, _, next) => {
   let query = req.body?.query || (req.query.query && decodeURIComponent(req.query.query))
   // Only log requests that contain a query
@@ -60,7 +41,7 @@ const queryLogger = (req, _, next) => {
   // If query is multiline string, add newline padding to front
   let formattedQuery = query.includes('\n') ? `\n${query}` : query
   // Sanitize all values between parentheses
-  if (IS_PRODUCTION) formattedQuery = _sanitizeArguments(formattedQuery)
+  if (IS_PRODUCTION) formattedQuery = formattedQuery.replace(/\([\s\S]*?\)/g, '( *** )')
 
   // Don't log undefined values
   LOG.info(...[req.method, formattedQueryInfo, formattedQuery].filter(e => e))

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,6 +3,7 @@ const { decodeURIComponent } = cds.utils
 const { IS_PRODUCTION } = require('./utils')
 const util = require('util')
 const LOG = cds.log('graphql')
+const { parse, visit, Kind, print } = require('graphql')
 
 const _isEmptyObject = o => Object.keys(o).length === 0
 
@@ -13,7 +14,6 @@ const queryLogger = (req, _, next) => {
     next()
     return
   }
-  query = query.trim()
 
   const operationName = req.body?.operationName || req.query?.operationName
 
@@ -38,13 +38,26 @@ const queryLogger = (req, _, next) => {
     ? undefined
     : util.formatWithOptions({ colors: false, depth: null }, queryInfo)
 
-  // If query is multiline string, add newline padding to front
-  let formattedQuery = query.includes('\n') ? `\n${query}` : query
-  // Sanitize all values between parentheses
-  if (IS_PRODUCTION) formattedQuery = formattedQuery.replace(/\([\s\S]*?\)/g, '( *** )')
+  query = query.trim()
+
+  if (IS_PRODUCTION) {
+    try {
+      const ast = parse(query)
+      // Sanitize all arguments unless they are variables
+      visit(ast, {
+        [Kind.ARGUMENT](node) {
+          if (node.value.kind === Kind.VARIABLE) return
+          node.value = { kind: Kind.STRING, value: '***' }
+        }
+      })
+      query = print(ast)
+    } catch (e) {
+      // If parsing or sanitizing the query fails, log the original query
+    }
+  }
 
   // Don't log undefined values
-  LOG.info(...[req.method, formattedQueryInfo, formattedQuery].filter(e => e))
+  LOG.info(...[req.method, formattedQueryInfo, '\n', query].filter(e => e))
 
   next()
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,5 @@
+const express = require('express')
+const router = express.Router()
 const cds = require('@sap/cds')
 const { decodeURIComponent } = cds.utils
 const { IS_PRODUCTION } = require('./utils')
@@ -7,7 +9,9 @@ const { parse, visit, Kind, print } = require('graphql')
 
 const _isEmptyObject = o => Object.keys(o).length === 0
 
-const queryLogger = (req, _, next) => {
+router.use(express.json({ ...cds.env.server.body_parser })) //> required by logger below
+
+router.use(function queryLogger(req, _, next) {
   let query = req.body?.query || (req.query.query && decodeURIComponent(req.query.query))
   // Only log requests that contain a query
   if (!query) {
@@ -60,6 +64,6 @@ const queryLogger = (req, _, next) => {
   LOG.info(...[req.method, formattedQueryInfo, '\n', query].filter(e => e))
 
   next()
-}
+})
 
-module.exports = queryLogger
+module.exports = router

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -55,7 +55,7 @@ router.use(function queryLogger(req, _, next) {
         }
       })
       query = print(ast)
-    } catch (e) {
+    } catch {
       // If parsing or sanitizing the query fails, log the original query
     }
   }

--- a/test/tests/error-handling-dev.test.js
+++ b/test/tests/error-handling-dev.test.js
@@ -7,13 +7,17 @@ describe('graphql - error handling in development', () => {
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
 
+  let _warn = []
+  let _error = []
+
   beforeEach(() => {
-    jest.spyOn(console, 'warn')
-    jest.spyOn(console, 'error')
+    console.warn = (...s) => _warn.push(s) // eslint-disable-line no-console
+    console.error = (...s) => _error.push(s) // eslint-disable-line no-console
   })
 
   afterEach(() => {
-    jest.clearAllMocks()
+    _warn = []
+    _error = []
   })
 
   describe('Errors thrown by CDS', () => {
@@ -33,7 +37,7 @@ describe('graphql - error handling in development', () => {
         {
           message: expect.any(String),
           extensions: {
-            code: expect.stringMatching(/ASSERT_MANDATORY|ASSERT_NOT_NULL/) ,
+            code: expect.stringMatching(/ASSERT_MANDATORY|ASSERT_NOT_NULL/),
             target: 'notEmptyI',
             stacktrace: expect.any(Array)
           }
@@ -63,13 +67,13 @@ describe('graphql - error handling in development', () => {
             code: 'MULTIPLE_ERRORS',
             details: [
               {
-                code: expect.stringMatching(/ASSERT_MANDATORY|ASSERT_NOT_NULL/) ,
+                code: expect.stringMatching(/ASSERT_MANDATORY|ASSERT_NOT_NULL/),
                 message: expect.any(String),
                 target: 'notEmptyI',
                 stacktrace: expect.any(Array)
               },
               {
-                code: expect.stringMatching(/ASSERT_MANDATORY|ASSERT_NOT_NULL/) ,
+                code: expect.stringMatching(/ASSERT_MANDATORY|ASSERT_NOT_NULL/),
                 message: expect.any(String),
                 target: 'notEmptyS',
                 stacktrace: expect.any(Array)
@@ -132,7 +136,7 @@ describe('graphql - error handling in development', () => {
             code: 'MULTIPLE_ERRORS',
             details: [
               { target: 'inRange', message: 'Wert ist erforderlich' },
-              { target: 'oneOfEnumValues', message: expect.any(String) },
+              { target: 'oneOfEnumValues', message: expect.any(String) }
             ]
           }
         }
@@ -143,7 +147,7 @@ describe('graphql - error handling in development', () => {
       expect(response.data.errors[0].extensions.details[0].stacktrace[0]).not.toHaveLength(0) // Stacktrace exists and is not empty
       expect(response.data.errors[0].extensions.details[1].stacktrace[0]).not.toHaveLength(0) // Stacktrace exists and is not empty
 
-      const log = console.warn.mock.calls[0][1]
+      const log = _warn[0][1]
       expect(log).toMatchObject({
         code: 'MULTIPLE_ERRORS',
         details: [
@@ -151,7 +155,7 @@ describe('graphql - error handling in development', () => {
           { target: 'oneOfEnumValues', code: 'ASSERT_ENUM' }
         ]
       })
-      expect(console.warn.mock.calls[0][1]).not.toHaveProperty('stacktrace') // No stacktrace outside of error details
+      expect(_warn[0][1]).not.toHaveProperty('stacktrace') // No stacktrace outside of error details
     })
   })
 
@@ -335,7 +339,7 @@ describe('graphql - error handling in development', () => {
       expect(response.data.errors[0].extensions).not.toHaveProperty('stacktrace') // No stacktrace outside of error details
       expect(response.data.errors[0].extensions.details[0].stacktrace[0]).not.toHaveLength(0) // Stacktrace exists and is not empty
       expect(response.data.errors[0].extensions.details[1].stacktrace[0]).not.toHaveLength(0) // Stacktrace exists and is not empty
-      expect(console.error.mock.calls[0][1]).toMatchObject({
+      expect(_error[0][1]).toMatchObject({
         code: 'MULTIPLE_ERRORS',
         details: [
           {
@@ -354,7 +358,7 @@ describe('graphql - error handling in development', () => {
           }
         ]
       })
-      expect(console.error.mock.calls[0][1]).not.toHaveProperty('stacktrace') // No stacktrace outside of error details
+      expect(_error[0][1]).not.toHaveProperty('stacktrace') // No stacktrace outside of error details
     })
 
     test('Thrown error is modified in srv.on(error) handler', async () => {

--- a/test/tests/logger-dev.test.js
+++ b/test/tests/logger-dev.test.js
@@ -10,15 +10,14 @@ describe('graphql - query logging in development', () => {
 
   const _format = e => util.formatWithOptions({ colors: false, depth: null }, ...(Array.isArray(e) ? e : [e]))
 
-  let _log
+  let _info = []
 
-  beforeEach(async () => {
-    await data.reset()
-    _log = jest.spyOn(console, 'info')
+  beforeEach(() => {
+    console.info = (...s) => _info.push(s) // eslint-disable-line no-console
   })
 
   afterEach(() => {
-    jest.clearAllMocks()
+    _info = []
   })
 
   describe('POST requests', () => {
@@ -26,7 +25,7 @@ describe('graphql - query logging in development', () => {
       const response = await POST('/graphql')
       expect(response.status).toEqual(400)
       expect(response.data.errors[0]).toEqual({ message: 'Missing query' })
-      expect(_log.mock.calls.length).toEqual(0)
+      expect(_info.length).toEqual(0)
     })
 
     test('Log should contain HTTP method', async () => {
@@ -42,7 +41,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).toContain('POST')
+      expect(_format(_info[0])).toContain('POST')
     })
 
     test('Log should not contain operationName if none was provided', async () => {
@@ -58,7 +57,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain('operationName')
+      expect(_format(_info[0])).not.toContain('operationName')
     })
 
     test('Log should not contain variables if none were provided', async () => {
@@ -74,7 +73,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain('variables')
+      expect(_format(_info[0])).not.toContain('variables')
     })
 
     test('Log should contain operationName and its value', async () => {
@@ -100,7 +99,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await POST('/graphql', { operationName, query })
-      expect(_format(_log.mock.calls[0])).toContain(`operationName: '${operationName}'`)
+      expect(_format(_info[0])).toContain(`operationName: '${operationName}'`)
     })
 
     test('Log should contain literal values', async () => {
@@ -117,7 +116,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).toContain(secretTitle)
+      expect(_format(_info[0])).toContain(secretTitle)
     })
 
     test('Log should contain variables and their values', async () => {
@@ -134,7 +133,7 @@ describe('graphql - query logging in development', () => {
       `
       const variables = { filter: { ID: { ge: 250 } } }
       await POST('/graphql', { query, variables })
-      expect(_format(_log.mock.calls[0])).toContain(`variables: ${_format(variables)}`)
+      expect(_format(_info[0])).toContain(`variables: ${_format(variables)}`)
     })
   })
 
@@ -143,7 +142,7 @@ describe('graphql - query logging in development', () => {
       const response = await GET('/graphql')
       expect(response.status).toEqual(200)
       expect(response.data).toMatch(/html/i) // GraphiQL is returned
-      expect(_log.mock.calls.length).toEqual(0)
+      expect(_info.length).toEqual(0)
     })
 
     test('Log should contain HTTP method', async () => {
@@ -159,7 +158,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).toContain('GET')
+      expect(_format(_info[0])).toContain('GET')
     })
 
     test('Log should not contain operationName if none was provided', async () => {
@@ -175,7 +174,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain('operationName')
+      expect(_format(_info[0])).not.toContain('operationName')
     })
 
     test('Log should not contain variables if none were provided', async () => {
@@ -191,7 +190,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain('variables')
+      expect(_format(_info[0])).not.toContain('variables')
     })
 
     test('Log should contain operationName and its value', async () => {
@@ -217,7 +216,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await GET(`/graphql?operationName=${operationName}&query=${query}`)
-      expect(_format(_log.mock.calls[0])).toContain(`operationName: '${operationName}'`)
+      expect(_format(_info[0])).toContain(`operationName: '${operationName}'`)
     })
 
     test('Log should contain literal values', async () => {
@@ -234,7 +233,7 @@ describe('graphql - query logging in development', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).toContain(secretTitle)
+      expect(_format(_info[0])).toContain(secretTitle)
     })
 
     test('Log should contain variables and their values', async () => {
@@ -251,7 +250,7 @@ describe('graphql - query logging in development', () => {
       `
       const variables = { filter: { ID: { ge: 250 } } }
       await GET(`/graphql?query=${query}&variables=${JSON.stringify(variables)}`)
-      expect(_format(_log.mock.calls[0])).toContain(`variables: ${_format(variables)}`)
+      expect(_format(_info[0])).toContain(`variables: ${_format(variables)}`)
     })
   })
 })

--- a/test/tests/logger-prod.test.js
+++ b/test/tests/logger-prod.test.js
@@ -172,7 +172,7 @@ describe('graphql - query logging with sanitization in production', () => {
       expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
     })
 
-    test('Log should not contain variables or their values', async () => {
+    test('Log should not contain variable values', async () => {
       const secretTitle = 'secret'
       const query = gql`
         mutation ($input: [AdminService_Books_C]!) {
@@ -187,7 +187,6 @@ describe('graphql - query logging with sanitization in production', () => {
       `
       const variables = { input: { title: secretTitle } }
       await POST('/graphql', { query, variables })
-      expect(_format(_log.mock.calls[0])).not.toContain('$input')
       expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
     })
   })
@@ -342,7 +341,7 @@ describe('graphql - query logging with sanitization in production', () => {
       expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
     })
 
-    test('Log should not contain variables or their values', async () => {
+    test('Log should not contain variable values', async () => {
       const secretTitle = 'secret'
       const query = gql`
         query ($filter: [AdminService_Books_filter]) {
@@ -357,7 +356,6 @@ describe('graphql - query logging with sanitization in production', () => {
       `
       const variables = { filter: { title: { ne: secretTitle } } }
       await GET(`/graphql?query=${query}&variables=${JSON.stringify(variables)}`)
-      expect(_format(_log.mock.calls[0])).not.toContain('$filter')
       expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
     })
   })

--- a/test/tests/logger-prod.test.js
+++ b/test/tests/logger-prod.test.js
@@ -11,15 +11,14 @@ describe('graphql - query logging with sanitization in production', () => {
 
   const _format = e => util.formatWithOptions({ colors: false, depth: null }, ...(Array.isArray(e) ? e : [e]))
 
-  let _log
+  let _info = []
 
-  beforeEach(async () => {
-    await data.reset()
-    _log = jest.spyOn(console, 'info')
+  beforeEach(() => {
+    console.info = (...s) => _info.push(s) // eslint-disable-line no-console
   })
 
   afterEach(() => {
-    jest.clearAllMocks()
+    _info = []
   })
 
   describe('POST requests', () => {
@@ -27,7 +26,7 @@ describe('graphql - query logging with sanitization in production', () => {
       const response = await POST('/graphql')
       expect(response.status).toEqual(400)
       expect(response.data.errors[0]).toEqual({ message: 'Missing query' })
-      expect(_log.mock.calls.length).toEqual(0)
+      expect(_info.length).toEqual(0)
     })
 
     test('Log should contain HTTP method', async () => {
@@ -43,7 +42,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).toContain('POST')
+      expect(_format(_info[0])).toContain('POST')
     })
 
     test('Log should not contain operationName if none was provided', async () => {
@@ -59,7 +58,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain('operationName')
+      expect(_format(_info[0])).not.toContain('operationName')
     })
 
     test('Log should not contain variables if none were provided', async () => {
@@ -75,7 +74,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain('variables')
+      expect(_format(_info[0])).not.toContain('variables')
     })
 
     test('Log should contain operationName and its value', async () => {
@@ -101,7 +100,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { operationName, query })
-      expect(_format(_log.mock.calls[0])).toContain(`operationName: '${operationName}'`)
+      expect(_format(_info[0])).toContain(`operationName: '${operationName}'`)
     })
 
     test('Log should not contain literal values', async () => {
@@ -118,9 +117,9 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
-    
+
     test('Log should not contain literal values that contain parentheses', async () => {
       const secretTitle = 'secret'
       const query = gql`
@@ -135,7 +134,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain literal values that contain unmatched opening parentheses', async () => {
@@ -152,7 +151,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain literal values that contain unmatched closing parentheses', async () => {
@@ -169,7 +168,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await POST('/graphql', { query })
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain variable values', async () => {
@@ -187,7 +186,7 @@ describe('graphql - query logging with sanitization in production', () => {
       `
       const variables = { input: { title: secretTitle } }
       await POST('/graphql', { query, variables })
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
   })
 
@@ -196,7 +195,7 @@ describe('graphql - query logging with sanitization in production', () => {
       const response = await GET('/graphql')
       expect(response.status).toEqual(200)
       expect(response.data).toMatch(/html/i) // GraphiQL is returned
-      expect(_log.mock.calls.length).toEqual(0)
+      expect(_info.length).toEqual(0)
     })
 
     test('Log should contain HTTP method', async () => {
@@ -212,7 +211,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).toContain('GET')
+      expect(_format(_info[0])).toContain('GET')
     })
 
     test('Log should not contain operationName if none was provided', async () => {
@@ -228,7 +227,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain('operationName')
+      expect(_format(_info[0])).not.toContain('operationName')
     })
 
     test('Log should not contain variables if none were provided', async () => {
@@ -244,7 +243,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain('variables')
+      expect(_format(_info[0])).not.toContain('variables')
     })
 
     test('Log should contain operationName and its value', async () => {
@@ -270,7 +269,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?operationName=${operationName}&query=${query}`)
-      expect(_format(_log.mock.calls[0])).toContain(`operationName: '${operationName}'`)
+      expect(_format(_info[0])).toContain(`operationName: '${operationName}'`)
     })
 
     test('Log should not contain literal values', async () => {
@@ -287,7 +286,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain literal values that contain parentheses', async () => {
@@ -304,7 +303,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain literal values that contain unmatched opening parentheses', async () => {
@@ -321,7 +320,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain literal values that contain unmatched closing parentheses', async () => {
@@ -338,7 +337,7 @@ describe('graphql - query logging with sanitization in production', () => {
         }
       `
       await GET(`/graphql?query=${query}`)
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
 
     test('Log should not contain variable values', async () => {
@@ -356,7 +355,7 @@ describe('graphql - query logging with sanitization in production', () => {
       `
       const variables = { filter: { title: { ne: secretTitle } } }
       await GET(`/graphql?query=${query}&variables=${JSON.stringify(variables)}`)
-      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+      expect(_format(_info[0])).not.toContain(secretTitle)
     })
   })
 })

--- a/test/tests/logger-prod.test.js
+++ b/test/tests/logger-prod.test.js
@@ -120,6 +120,57 @@ describe('graphql - query logging with sanitization in production', () => {
       await POST('/graphql', { query })
       expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
     })
+    
+    test('Log should not contain literal values that contain parentheses', async () => {
+      const secretTitle = 'secret'
+      const query = gql`
+        mutation {
+          AdminService {
+            Books {
+              create (input: { title: "() ${secretTitle}" }) {
+                title
+              }
+            }
+          }
+        }
+      `
+      await POST('/graphql', { query })
+      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+    })
+
+    test('Log should not contain literal values that contain unmatched opening parentheses', async () => {
+      const secretTitle = 'secret'
+      const query = gql`
+        mutation {
+          AdminService {
+            Books {
+              create (input: { title: "${secretTitle} (" }) {
+                title
+              }
+            }
+          }
+        }
+      `
+      await POST('/graphql', { query })
+      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+    })
+
+    test('Log should not contain literal values that contain unmatched closing parentheses', async () => {
+      const secretTitle = 'secret'
+      const query = gql`
+        mutation {
+          AdminService {
+            Books {
+              create (input: { title: ") ${secretTitle}" }) {
+                title
+              }
+            }
+          }
+        }
+      `
+      await POST('/graphql', { query })
+      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+    })
 
     test('Log should not contain variables or their values', async () => {
       const secretTitle = 'secret'
@@ -230,6 +281,57 @@ describe('graphql - query logging with sanitization in production', () => {
           AdminService {
             Books(filter: { title: { ne: "${secretTitle}"}}) {
               nodes {
+                title
+              }
+            }
+          }
+        }
+      `
+      await GET(`/graphql?query=${query}`)
+      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+    })
+
+    test('Log should not contain literal values that contain parentheses', async () => {
+      const secretTitle = 'secret'
+      const query = gql`
+        mutation {
+          AdminService {
+            Books {
+              create (input: { title: "() ${secretTitle}" }) {
+                title
+              }
+            }
+          }
+        }
+      `
+      await GET(`/graphql?query=${query}`)
+      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+    })
+
+    test('Log should not contain literal values that contain unmatched opening parentheses', async () => {
+      const secretTitle = 'secret'
+      const query = gql`
+        mutation {
+          AdminService {
+            Books {
+              create (input: { title: "${secretTitle} (" }) {
+                title
+              }
+            }
+          }
+        }
+      `
+      await GET(`/graphql?query=${query}`)
+      expect(_format(_log.mock.calls[0])).not.toContain(secretTitle)
+    })
+
+    test('Log should not contain literal values that contain unmatched closing parentheses', async () => {
+      const secretTitle = 'secret'
+      const query = gql`
+        mutation {
+          AdminService {
+            Books {
+              create (input: { title: ") ${secretTitle}" }) {
                 title
               }
             }


### PR DESCRIPTION
Example query:

```gql
query MyQuery {
  AdminService {
    Books(filter: {title: {contains: ") foo"}}) {
      nodes {
        ID
      }
    }
  }
}
```

Previous log output (in production):

```gql
[graphql] - POST { operationName: 'MyQuery' } 
query MyQuery {
  AdminService {
    Books( *** ) foo"}}) {
      nodes {
        ID
      }
    }
  }
}
```

New log output (in production):

```gql
[graphql] - POST { operationName: 'MyQuery' } 
 query MyQuery {
  AdminService {
    Books(filter: "***") {
      nodes {
        ID
      }
    }
  }
}
```